### PR TITLE
TensorLIC: Aspect ratio fix and adjustable background color

### DIFF
--- a/tensorvis/tensorvisbase/glsl/tensorlic2d.frag
+++ b/tensorvis/tensorvisbase/glsl/tensorlic2d.frag
@@ -55,7 +55,7 @@ in vec3 texCoord_;
 void traverse(inout float v, inout int c, vec2 posForTensorFieldSampling, float stepSize,
               int steps) {
     vec2 previousV0 =
-        rk4(vec2(posForTensorFieldSampling.x,posForTensorFieldSampling.y), stepSize, useMinor, tensorFieldColor, normalizeVectors);
+        rk4(posForTensorFieldSampling, stepSize, useMinor, tensorFieldColor, normalizeVectors);
 
     for (int i = 0; i < steps; i++) {
         vec2 V0;

--- a/tensorvis/tensorvisbase/glsl/tensorlic2d.frag
+++ b/tensorvis/tensorvisbase/glsl/tensorlic2d.frag
@@ -47,13 +47,15 @@ uniform float eigenValueRange;
 uniform float minEigenValue;
 uniform float maxEigenValue;
 uniform bool hasInputImage;
+uniform float ratio;
+uniform vec4 backgroundColor;
 
 in vec3 texCoord_;
 
 void traverse(inout float v, inout int c, vec2 posForTensorFieldSampling, float stepSize,
               int steps) {
     vec2 previousV0 =
-        rk4(posForTensorFieldSampling, stepSize, useMinor, tensorFieldColor, normalizeVectors);
+        rk4(vec2(posForTensorFieldSampling.x,posForTensorFieldSampling.y), stepSize, useMinor, tensorFieldColor, normalizeVectors);
 
     for (int i = 0; i < steps; i++) {
         vec2 V0;
@@ -68,6 +70,10 @@ void traverse(inout float v, inout int c, vec2 posForTensorFieldSampling, float 
         if (dot(previousV0, V0) < 0) {
             V0 = -V0;
         }
+
+        V0.x = ratio * V0.x;
+
+        V0 = normalize(V0);
 
         previousV0 = V0;
 
@@ -104,7 +110,7 @@ void main() {
     vec4 tensorVector = texture(tensorFieldColor, newTexForNoiseTextureSampling);
     if (tensorVector[0] == 0 && tensorVector[1] == 0 && tensorVector[2] == 0 &&
         tensorVector[3] == 0) {
-        FragData0 = vec4(1);
+        FragData0 = backgroundColor;
         return;
     }
 

--- a/tensorvis/tensorvisbase/include/modules/tensorvisbase/processors/tensorfieldlic.h
+++ b/tensorvis/tensorvisbase/include/modules/tensorvisbase/processors/tensorfieldlic.h
@@ -37,6 +37,8 @@
 #include <modules/tensorvisbase/datastructures/tensorfield2d.h>
 #include <modules/opengl/shader/shaderutils.h>
 #include <modules/tensorvisbase/util/tensorfieldutil.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/properties/ordinalproperty.h>
 
 namespace inviwo {
 
@@ -83,6 +85,7 @@ private:
     BoolProperty intensityMapping_;
     BoolProperty useRK4_;
     BoolProperty majorMinor_;
+    FloatVec4Property backgroundColor_;
 
     Shader shader_;
     Image tf_texture_;

--- a/tensorvis/tensorvisbase/src/processors/tensorfieldlic.cpp
+++ b/tensorvis/tensorvisbase/src/processors/tensorfieldlic.cpp
@@ -142,8 +142,9 @@ void TensorFieldLIC::process() {
     shader_.setUniform("eigenValueRange", eigenValueRange_);
     shader_.setUniform("hasInputImage", hasInputImage);
 
-    auto dDimensions = vec2(outport_.getDimensions());
-    auto ratio = std::min(dDimensions.x, dDimensions.y) / std::max(dDimensions.x, dDimensions.y);
+    const auto dDimensions = vec2(outport_.getDimensions());
+    const auto ratio =
+        std::min(dDimensions.x, dDimensions.y) / std::max(dDimensions.x, dDimensions.y);
 
     shader_.setUniform("ratio", ratio);
 

--- a/tensorvis/tensorvisbase/src/processors/tensorfieldlic.cpp
+++ b/tensorvis/tensorvisbase/src/processors/tensorfieldlic.cpp
@@ -55,6 +55,8 @@ TensorFieldLIC::TensorFieldLIC()
     , intensityMapping_("intensityMapping", "Enable intensity remapping", false)
     , useRK4_("useRK4", "Use Runge-Kutta4", true)
     , majorMinor_("useMinor", "Use minor eigenvectors", false)
+    , backgroundColor_("backgroundColor", "Background color", vec4(1.0f), vec4(0.0f), vec4(1.0f),
+                       vec4(0.01f), InvalidationLevel::InvalidOutput, PropertySemantics::Color)
     , shader_("tensorlic2d.frag") {
     imageInport_.setOptional(true);
 
@@ -64,6 +66,7 @@ TensorFieldLIC::TensorFieldLIC()
     addProperty(intensityMapping_);
     addProperty(useRK4_);
     addProperty(majorMinor_);
+    addProperty(backgroundColor_);
 
     shader_.onReload([&]() { invalidate(InvalidationLevel::InvalidOutput); });
 
@@ -133,11 +136,16 @@ void TensorFieldLIC::process() {
     updateEigenValues();
 
     utilgl::setUniforms(shader_, outport_, samples_, stepLength_, normalizeVectors_,
-                        intensityMapping_, useRK4_, majorMinor_);
+                        intensityMapping_, useRK4_, majorMinor_, backgroundColor_);
     shader_.setUniform("minEigenValue", minVal_);
     shader_.setUniform("maxEigenValue", maxVal_);
     shader_.setUniform("eigenValueRange", eigenValueRange_);
     shader_.setUniform("hasInputImage", hasInputImage);
+
+    auto dDimensions = vec2(outport_.getDimensions());
+    auto ratio = std::min(dDimensions.x, dDimensions.y) / std::max(dDimensions.x, dDimensions.y);
+
+    shader_.setUniform("ratio", ratio);
 
     utilgl::singleDrawImagePlaneRect();
     shader_.deactivate();


### PR DESCRIPTION
When aspect ratio != 1:1, the LIC produced structures for the major and minor eigenvector field that where not orthogonal due to a missing transformation (non-uniform scaling).

In addition, the background color of the LIC can now be adjusted.