### PR TITLE
TensorVisIO: redirecting VTK logging to Inviwo

### DIFF
--- a/tensorvis/tensorvisio/CMakeLists.txt
+++ b/tensorvis/tensorvisio/CMakeLists.txt
@@ -8,43 +8,45 @@ include(${VTK_USE_FILE})
 #--------------------------------------------------------------------
 # Add header files
 set(HEADER_FILES
-    include/modules/tensorvisio/tensorvisiomodule.h
-    include/modules/tensorvisio/tensorvisiomoduledefine.h
-    include/modules/tensorvisio/processors/vtkstructuredgridreader.h
-    include/modules/tensorvisio/processors/vtkunstructuredgridtorectilineargrid.h
-    include/modules/tensorvisio/processors/witofilereader.h
+    include/modules/tensorvisio/processors/amiratensorreader.h
+    include/modules/tensorvisio/processors/nrrdreader.h
     include/modules/tensorvisio/processors/tensorfield2dexport.h
     include/modules/tensorvisio/processors/tensorfield2dimport.h
-    include/modules/tensorvisio/processors/nrrdreader.h
-    include/modules/tensorvisio/processors/vtktotensorfield3d.h
     include/modules/tensorvisio/processors/tensorfield3dexport.h
     include/modules/tensorvisio/processors/tensorfield3dimport.h
-    include/modules/tensorvisio/processors/amiratensorreader.h
     include/modules/tensorvisio/processors/vtkrectilineargridreader.h
-    include/modules/tensorvisio/processors/vtkxmlrectilineargridreader.h
+    include/modules/tensorvisio/processors/vtkstructuredgridreader.h
     include/modules/tensorvisio/processors/vtkstructuredpointsreader.h
+    include/modules/tensorvisio/processors/vtktotensorfield3d.h
+    include/modules/tensorvisio/processors/vtkunstructuredgridtorectilineargrid.h
     include/modules/tensorvisio/processors/vtkvolumereader.h
+    include/modules/tensorvisio/processors/vtkxmlrectilineargridreader.h
+    include/modules/tensorvisio/processors/witofilereader.h
+    include/modules/tensorvisio/tensorvisiomodule.h
+    include/modules/tensorvisio/tensorvisiomoduledefine.h
+    include/modules/tensorvisio/util/vtkoutputlogger.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
 
 #--------------------------------------------------------------------
 # Add source files
 set(SOURCE_FILES
-    src/tensorvisiomodule.cpp
-    src/processors/vtkstructuredgridreader.cpp
-    src/processors/vtkunstructuredgridtorectilineargrid.cpp
-    src/processors/witofilereader.cpp
     src/processors/amiratensorreader.cpp
     src/processors/nrrdreader.cpp
     src/processors/tensorfield2dexport.cpp
     src/processors/tensorfield2dimport.cpp
     src/processors/tensorfield3dexport.cpp
     src/processors/tensorfield3dimport.cpp
-    src/processors/vtktotensorfield3d.cpp
     src/processors/vtkrectilineargridreader.cpp
-    src/processors/vtkxmlrectilineargridreader.cpp
+    src/processors/vtkstructuredgridreader.cpp
     src/processors/vtkstructuredpointsreader.cpp
+    src/processors/vtktotensorfield3d.cpp
+    src/processors/vtkunstructuredgridtorectilineargrid.cpp
     src/processors/vtkvolumereader.cpp
+    src/processors/vtkxmlrectilineargridreader.cpp
+    src/processors/witofilereader.cpp
+    src/tensorvisiomodule.cpp
+    src/util/vtkoutputlogger.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 

--- a/tensorvis/tensorvisio/include/modules/tensorvisio/tensorvisiomodule.h
+++ b/tensorvis/tensorvisio/include/modules/tensorvisio/tensorvisiomodule.h
@@ -35,12 +35,17 @@
 
 namespace inviwo {
 
+class VtkOutputLogger;
+
 class IVW_MODULE_TENSORVISIO_API TensorVisIOModule : public InviwoModule {
 public:
     TensorVisIOModule(InviwoApplication* app);
     virtual ~TensorVisIOModule() = default;
+
+private:
+    std::shared_ptr<VtkOutputLogger> vtkoutput_;
 };
 
-} // namespace
+}  // namespace inviwo
 
-#endif // IVW_TENSORFIELDIOMODULE_H
+#endif  // IVW_TENSORFIELDIOMODULE_H

--- a/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkoutputlogger.h
+++ b/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkoutputlogger.h
@@ -30,7 +30,6 @@
 
 #include <modules/tensorvisio/tensorvisiomoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/util/singleton.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -42,22 +41,15 @@ namespace inviwo {
 class InviwoVtkOutputWindow;
 
 /** \class VtkOutputLogger
- * \brief singleton for mapping VTK logging output to Inviwo's logcentral instead of the regular VTK
- * output window
+ * \brief mapping VTK logging output to Inviwo's logcentral instead of the regular VTK output window
  */
-class IVW_MODULE_TENSORVISIO_API VtkOutputLogger : public Singleton<VtkOutputLogger> {
+class IVW_MODULE_TENSORVISIO_API VtkOutputLogger {
 public:
     VtkOutputLogger();
-    VtkOutputLogger(const VtkOutputLogger&) = delete;
-    VtkOutputLogger& operator=(const VtkOutputLogger&) = delete;
-
     virtual ~VtkOutputLogger() = default;
 
 private:
     vtkSmartPointer<InviwoVtkOutputWindow> outputWindow_;
-
-    friend Singleton<VtkOutputLogger>;
-    static VtkOutputLogger* instance_;
 };
 
 }  // namespace inviwo

--- a/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkoutputlogger.h
+++ b/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkoutputlogger.h
@@ -1,0 +1,63 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <modules/tensorvisio/tensorvisiomoduledefine.h>
+#include <inviwo/core/common/inviwo.h>
+#include <inviwo/core/util/singleton.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <vtkSmartPointer.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+class InviwoVtkOutputWindow;
+
+/** \class VtkOutputLogger
+ * \brief singleton for mapping VTK logging output to Inviwo's logcentral instead of the regular VTK
+ * output window
+ */
+class IVW_MODULE_TENSORVISIO_API VtkOutputLogger : public Singleton<VtkOutputLogger> {
+public:
+    VtkOutputLogger();
+    VtkOutputLogger(const VtkOutputLogger&) = delete;
+    VtkOutputLogger& operator=(const VtkOutputLogger&) = delete;
+
+    virtual ~VtkOutputLogger() = default;
+
+private:
+    vtkSmartPointer<InviwoVtkOutputWindow> outputWindow_;
+
+    friend Singleton<VtkOutputLogger>;
+    static VtkOutputLogger* instance_;
+};
+
+}  // namespace inviwo

--- a/tensorvis/tensorvisio/src/tensorvisiomodule.cpp
+++ b/tensorvis/tensorvisio/src/tensorvisiomodule.cpp
@@ -47,8 +47,8 @@
 
 namespace inviwo {
 
-TensorVisIOModule::TensorVisIOModule(InviwoApplication* app) : InviwoModule(app, "TensorVisIO") {
-    VtkOutputLogger::init();
+TensorVisIOModule::TensorVisIOModule(InviwoApplication* app)
+    : InviwoModule{app, "TensorVisIO"}, vtkoutput_{std::make_shared<VtkOutputLogger>()} {
 
     registerProcessor<AmiraTensorReader>();
     registerProcessor<NRRDReader>();

--- a/tensorvis/tensorvisio/src/tensorvisiomodule.cpp
+++ b/tensorvis/tensorvisio/src/tensorvisiomodule.cpp
@@ -43,12 +43,15 @@
 #include <modules/tensorvisio/processors/vtkxmlrectilineargridreader.h>
 #include <modules/tensorvisio/processors/vtkstructuredpointsreader.h>
 #include <modules/tensorvisio/processors/vtkvolumereader.h>
+#include <modules/tensorvisio/util/vtkoutputlogger.h>
 
 namespace inviwo {
 
-TensorVisIOModule::TensorVisIOModule(InviwoApplication* app) : InviwoModule(app, "TensorVisIO") {   
-	registerProcessor<AmiraTensorReader>();
-	registerProcessor<NRRDReader>();
+TensorVisIOModule::TensorVisIOModule(InviwoApplication* app) : InviwoModule(app, "TensorVisIO") {
+    VtkOutputLogger::init();
+
+    registerProcessor<AmiraTensorReader>();
+    registerProcessor<NRRDReader>();
     registerProcessor<TensorField2DExport>();
     registerProcessor<TensorField2DImport>();
     registerProcessor<TensorField3DExport>();
@@ -63,4 +66,4 @@ TensorVisIOModule::TensorVisIOModule(InviwoApplication* app) : InviwoModule(app,
     registerProcessor<VTKVolumeReader>();
 }
 
-} // namespace
+}  // namespace inviwo

--- a/tensorvis/tensorvisio/src/util/vtkoutputlogger.cpp
+++ b/tensorvis/tensorvisio/src/util/vtkoutputlogger.cpp
@@ -1,0 +1,80 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/tensorvisio/util/vtkoutputlogger.h>
+
+#include <inviwo/core/util/logcentral.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <vtkOutputWindow.h>
+#include <vtkObjectFactory.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+class InviwoVtkOutputWindow : public vtkOutputWindow {
+public:
+    InviwoVtkOutputWindow() = default;
+    virtual ~InviwoVtkOutputWindow() = default;
+
+    static InviwoVtkOutputWindow* New();
+
+    virtual void DisplayText(const char*) override;
+
+    virtual void DisplayErrorText(const char*) override;
+
+    virtual void DisplayWarningText(const char*) override;
+
+    virtual void DisplayGenericWarningText(const char*) override;
+
+    virtual void DisplayDebugText(const char*) override;
+};
+
+VtkOutputLogger* VtkOutputLogger::instance_ = nullptr;
+
+vtkStandardNewMacro(InviwoVtkOutputWindow);
+
+void InviwoVtkOutputWindow::DisplayText(const char* msg) { LogInfoCustom("VTK", msg); }
+
+void InviwoVtkOutputWindow::DisplayErrorText(const char* msg) { LogErrorCustom("VTK", msg); }
+
+void InviwoVtkOutputWindow::DisplayWarningText(const char* msg) { LogWarnCustom("VTK", msg); }
+
+void InviwoVtkOutputWindow::DisplayGenericWarningText(const char* msg) {
+    LogWarnCustom("VTK (Generic)", msg);
+}
+
+void InviwoVtkOutputWindow::DisplayDebugText(const char* msg) { LogInfoCustom("VTK (debug", msg); }
+
+VtkOutputLogger::VtkOutputLogger() : outputWindow_{vtkSmartPointer<InviwoVtkOutputWindow>::New()} {
+    vtkOutputWindow::SetInstance(outputWindow_);
+}
+
+}  // namespace inviwo

--- a/tensorvis/tensorvisio/src/util/vtkoutputlogger.cpp
+++ b/tensorvis/tensorvisio/src/util/vtkoutputlogger.cpp
@@ -57,21 +57,19 @@ public:
     virtual void DisplayDebugText(const char*) override;
 };
 
-VtkOutputLogger* VtkOutputLogger::instance_ = nullptr;
-
 vtkStandardNewMacro(InviwoVtkOutputWindow);
 
 void InviwoVtkOutputWindow::DisplayText(const char* msg) { LogInfoCustom("VTK", msg); }
 
-void InviwoVtkOutputWindow::DisplayErrorText(const char* msg) { LogErrorCustom("VTK", msg); }
+void InviwoVtkOutputWindow::DisplayErrorText(const char* msg) { LogErrorCustom("VTK (error)", msg); }
 
-void InviwoVtkOutputWindow::DisplayWarningText(const char* msg) { LogWarnCustom("VTK", msg); }
+void InviwoVtkOutputWindow::DisplayWarningText(const char* msg) { LogWarnCustom("VTK (warn)", msg); }
 
 void InviwoVtkOutputWindow::DisplayGenericWarningText(const char* msg) {
-    LogWarnCustom("VTK (Generic)", msg);
+    LogWarnCustom("VTK (generic)", msg);
 }
 
-void InviwoVtkOutputWindow::DisplayDebugText(const char* msg) { LogInfoCustom("VTK (debug", msg); }
+void InviwoVtkOutputWindow::DisplayDebugText(const char* msg) { LogInfoCustom("VTK (debug)", msg); }
 
 VtkOutputLogger::VtkOutputLogger() : outputWindow_{vtkSmartPointer<InviwoVtkOutputWindow>::New()} {
     vtkOutputWindow::SetInstance(outputWindow_);


### PR DESCRIPTION
Prevents VTK from showing its own (non-responsive) window and forward the vtk messages to Inviwo.
![image](https://user-images.githubusercontent.com/9251300/55566575-42902100-56fc-11e9-92f7-cae85e466237.png)
