### PR TITLE
TensorVisIO: redirecting VTK logging to Inviwo

### DIFF
--- a/tensorvis/tensorvisio/CMakeLists.txt
+++ b/tensorvis/tensorvisio/CMakeLists.txt
@@ -8,43 +8,45 @@ include(${VTK_USE_FILE})
 #--------------------------------------------------------------------
 # Add header files
 set(HEADER_FILES
-    include/modules/tensorvisio/tensorvisiomodule.h
-    include/modules/tensorvisio/tensorvisiomoduledefine.h
-    include/modules/tensorvisio/processors/vtkstructuredgridreader.h
-    include/modules/tensorvisio/processors/vtkunstructuredgridtorectilineargrid.h
-    include/modules/tensorvisio/processors/witofilereader.h
+    include/modules/tensorvisio/processors/amiratensorreader.h
+    include/modules/tensorvisio/processors/nrrdreader.h
     include/modules/tensorvisio/processors/tensorfield2dexport.h
     include/modules/tensorvisio/processors/tensorfield2dimport.h
-    include/modules/tensorvisio/processors/nrrdreader.h
-    include/modules/tensorvisio/processors/vtktotensorfield3d.h
     include/modules/tensorvisio/processors/tensorfield3dexport.h
     include/modules/tensorvisio/processors/tensorfield3dimport.h
-    include/modules/tensorvisio/processors/amiratensorreader.h
     include/modules/tensorvisio/processors/vtkrectilineargridreader.h
-    include/modules/tensorvisio/processors/vtkxmlrectilineargridreader.h
+    include/modules/tensorvisio/processors/vtkstructuredgridreader.h
     include/modules/tensorvisio/processors/vtkstructuredpointsreader.h
+    include/modules/tensorvisio/processors/vtktotensorfield3d.h
+    include/modules/tensorvisio/processors/vtkunstructuredgridtorectilineargrid.h
     include/modules/tensorvisio/processors/vtkvolumereader.h
+    include/modules/tensorvisio/processors/vtkxmlrectilineargridreader.h
+    include/modules/tensorvisio/processors/witofilereader.h
+    include/modules/tensorvisio/tensorvisiomodule.h
+    include/modules/tensorvisio/tensorvisiomoduledefine.h
+    include/modules/tensorvisio/util/vtkoutputlogger.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
 
 #--------------------------------------------------------------------
 # Add source files
 set(SOURCE_FILES
-    src/tensorvisiomodule.cpp
-    src/processors/vtkstructuredgridreader.cpp
-    src/processors/vtkunstructuredgridtorectilineargrid.cpp
-    src/processors/witofilereader.cpp
     src/processors/amiratensorreader.cpp
     src/processors/nrrdreader.cpp
     src/processors/tensorfield2dexport.cpp
     src/processors/tensorfield2dimport.cpp
     src/processors/tensorfield3dexport.cpp
     src/processors/tensorfield3dimport.cpp
-    src/processors/vtktotensorfield3d.cpp
     src/processors/vtkrectilineargridreader.cpp
-    src/processors/vtkxmlrectilineargridreader.cpp
+    src/processors/vtkstructuredgridreader.cpp
     src/processors/vtkstructuredpointsreader.cpp
+    src/processors/vtktotensorfield3d.cpp
+    src/processors/vtkunstructuredgridtorectilineargrid.cpp
     src/processors/vtkvolumereader.cpp
+    src/processors/vtkxmlrectilineargridreader.cpp
+    src/processors/witofilereader.cpp
+    src/tensorvisiomodule.cpp
+    src/util/vtkoutputlogger.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 

--- a/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkoutputlogger.h
+++ b/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkoutputlogger.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2017-2018 Inviwo Foundation
+ * Copyright (c) 2019 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,30 +26,30 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
-
-#ifndef IVW_TENSORFIELDIOMODULE_H
-#define IVW_TENSORFIELDIOMODULE_H
+#pragma once
 
 #include <modules/tensorvisio/tensorvisiomoduledefine.h>
-#include <inviwo/core/common/inviwomodule.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <vtkSmartPointer.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-class VtkOutputLogger;
+class InviwoVtkOutputWindow;
 
-class IVW_MODULE_TENSORVISIO_API TensorVisIOModule : public InviwoModule {
+/** \class VtkOutputLogger
+ * \brief mapping VTK logging output to Inviwo's logcentral instead of the regular VTK output window
+ */
+class IVW_MODULE_TENSORVISIO_API VtkOutputLogger {
 public:
-    TensorVisIOModule(InviwoApplication* app);
-    TensorVisIOModule(const TensorVisIOModule&) = delete;
-    TensorVisIOModule(TensorVisIOModule&&) = delete;
-    TensorVisIOModule& operator=(const TensorVisIOModule&) = delete;
-    TensorVisIOModule& operator=(TensorVisIOModule&&) = delete;
-    virtual ~TensorVisIOModule();
+    VtkOutputLogger();
+    virtual ~VtkOutputLogger() = default;
 
 private:
-    std::unique_ptr<VtkOutputLogger> vtkoutput_;
+    vtkSmartPointer<InviwoVtkOutputWindow> outputWindow_;
 };
 
 }  // namespace inviwo
-
-#endif  // IVW_TENSORFIELDIOMODULE_H

--- a/tensorvis/tensorvisio/src/tensorvisiomodule.cpp
+++ b/tensorvis/tensorvisio/src/tensorvisiomodule.cpp
@@ -43,12 +43,15 @@
 #include <modules/tensorvisio/processors/vtkxmlrectilineargridreader.h>
 #include <modules/tensorvisio/processors/vtkstructuredpointsreader.h>
 #include <modules/tensorvisio/processors/vtkvolumereader.h>
+#include <modules/tensorvisio/util/vtkoutputlogger.h>
 
 namespace inviwo {
 
-TensorVisIOModule::TensorVisIOModule(InviwoApplication* app) : InviwoModule(app, "TensorVisIO") {   
-	registerProcessor<AmiraTensorReader>();
-	registerProcessor<NRRDReader>();
+TensorVisIOModule::TensorVisIOModule(InviwoApplication* app)
+    : InviwoModule{app, "TensorVisIO"}, vtkoutput_{std::make_unique<VtkOutputLogger>()} {
+
+    registerProcessor<AmiraTensorReader>();
+    registerProcessor<NRRDReader>();
     registerProcessor<TensorField2DExport>();
     registerProcessor<TensorField2DImport>();
     registerProcessor<TensorField3DExport>();
@@ -63,4 +66,6 @@ TensorVisIOModule::TensorVisIOModule(InviwoApplication* app) : InviwoModule(app,
     registerProcessor<VTKVolumeReader>();
 }
 
-} // namespace
+TensorVisIOModule::~TensorVisIOModule() = default;
+
+}  // namespace inviwo

--- a/tensorvis/tensorvisio/src/util/vtkoutputlogger.cpp
+++ b/tensorvis/tensorvisio/src/util/vtkoutputlogger.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2017-2018 Inviwo Foundation
+ * Copyright (c) 2019 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,29 +27,52 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_TENSORFIELDIOMODULE_H
-#define IVW_TENSORFIELDIOMODULE_H
+#include <modules/tensorvisio/util/vtkoutputlogger.h>
 
-#include <modules/tensorvisio/tensorvisiomoduledefine.h>
-#include <inviwo/core/common/inviwomodule.h>
+#include <inviwo/core/util/logcentral.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <vtkOutputWindow.h>
+#include <vtkObjectFactory.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-class VtkOutputLogger;
-
-class IVW_MODULE_TENSORVISIO_API TensorVisIOModule : public InviwoModule {
+class InviwoVtkOutputWindow : public vtkOutputWindow {
 public:
-    TensorVisIOModule(InviwoApplication* app);
-    TensorVisIOModule(const TensorVisIOModule&) = delete;
-    TensorVisIOModule(TensorVisIOModule&&) = delete;
-    TensorVisIOModule& operator=(const TensorVisIOModule&) = delete;
-    TensorVisIOModule& operator=(TensorVisIOModule&&) = delete;
-    virtual ~TensorVisIOModule();
+    InviwoVtkOutputWindow() = default;
+    virtual ~InviwoVtkOutputWindow() = default;
 
-private:
-    std::unique_ptr<VtkOutputLogger> vtkoutput_;
+    static InviwoVtkOutputWindow* New();
+
+    virtual void DisplayText(const char*) override;
+
+    virtual void DisplayErrorText(const char*) override;
+
+    virtual void DisplayWarningText(const char*) override;
+
+    virtual void DisplayGenericWarningText(const char*) override;
+
+    virtual void DisplayDebugText(const char*) override;
 };
 
-}  // namespace inviwo
+vtkStandardNewMacro(InviwoVtkOutputWindow);
 
-#endif  // IVW_TENSORFIELDIOMODULE_H
+void InviwoVtkOutputWindow::DisplayText(const char* msg) { LogInfoCustom("VTK", msg); }
+
+void InviwoVtkOutputWindow::DisplayErrorText(const char* msg) { LogErrorCustom("VTK (error)", msg); }
+
+void InviwoVtkOutputWindow::DisplayWarningText(const char* msg) { LogWarnCustom("VTK (warn)", msg); }
+
+void InviwoVtkOutputWindow::DisplayGenericWarningText(const char* msg) {
+    LogWarnCustom("VTK (generic)", msg);
+}
+
+void InviwoVtkOutputWindow::DisplayDebugText(const char* msg) { LogInfoCustom("VTK (debug)", msg); }
+
+VtkOutputLogger::VtkOutputLogger() : outputWindow_{vtkSmartPointer<InviwoVtkOutputWindow>::New()} {
+    vtkOutputWindow::SetInstance(outputWindow_);
+}
+
+}  // namespace inviwo


### PR DESCRIPTION
rebased PR #10 including all requested changes

Prevents VTK from showing its own (non-responsive) window and forward the vtk messages to Inviwo.
![image](https://user-images.githubusercontent.com/9251300/55566575-42902100-56fc-11e9-92f7-cae85e466237.png)