### PR TITLE
SpringSys: Clang warning fix

### DIFF
--- a/misc/springsystem/include/inviwo/springsystem/datastructures/springsystem.h
+++ b/misc/springsystem/include/inviwo/springsystem/datastructures/springsystem.h
@@ -270,7 +270,7 @@ void SpringSystem<Components, ComponentType, Derived>::print(
         auto displacement = dir * (dist - derived().springLength(i));
 
         ss << "\n"
-           << std::setw(6) << (i++) << ":  l0 = " << derived().springLength(i) << ", l = " << dist
+           << std::setw(6) << (i + 1) << ":  l0 = " << derived().springLength(i) << ", l = " << dist
            << ", s = " << displacement;
     }
     ss << "\n-----------------------------";


### PR DESCRIPTION
The changed line generated an `unsequenced modification and access to 'i'` on jenkins.
Also, should it really be `i++` at that place? The for loop has an `i++`, hence: `i` is incremented twice each iteration and only every second spring is printed. 
If we want that then we should either move the `i++` ti the next line or use `i+=2` in the for-loop