### PR TITLE
Removing hack that masks lamdas as function pointers

### DIFF
--- a/tensorvis/tensorvisio/CMakeLists.txt
+++ b/tensorvis/tensorvisio/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HEADER_FILES
     include/modules/tensorvisio/processors/flowguifilereader.h
     include/modules/tensorvisio/tensorvisiomodule.h
     include/modules/tensorvisio/tensorvisiomoduledefine.h
+	include/modules/tensorvisio/util/vtkutil.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
 

--- a/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkutil.h
+++ b/tensorvis/tensorvisio/include/modules/tensorvisio/util/vtkutil.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <vtkObject.h>
+#include <vtkAlgorithm.h>
+#include <warn/pop>
+
+#include <inviwo/core/common/inviwoapplication.h>
+#include <inviwo/core/processors/progressbar.h>
+
+/**
+ * Global method used as a callback for vtkCallbackCommand. The method needs to be global, otherwise
+ * the signature will not match. clientData should be a pointer to the calling processor's
+ * progressbar.
+ * Note that you will need to explicitly set the client data via VTK's method SetClientData(void*)
+ *
+ * Example Usage:
+ *
+ *    auto progressCallback = vtkSmartPointer<vtkCallbackCommand>::New();
+ *    progressCallback->SetCallback(vtkProgressBarCallback);
+ *    progressCallback->SetClientData(&progressBar_);
+ *
+ *    auto someFilter = vtkSmartPointer<vtkSomeFilter>::New();
+ *
+ *    someFilter->AddObserver(vtkCommand::ProgressEvent, progressCallback);
+ *
+ */
+void vtkProgressBarCallback(vtkObject* caller, long unsigned int eventID, void* clientData,
+                            void* callData) {
+
+    if (auto algorithm = dynamic_cast<vtkAlgorithm*>(caller)) {
+
+        auto progressBar = static_cast<inviwo::ProgressBar*>(clientData);
+
+        if (progressBar) {
+
+            if (algorithm->GetProgress() > 0.0) {
+                const auto f = float(algorithm->GetProgress());
+
+                inviwo::dispatchFront([progressBar, f]() {
+                    f < 1.0f ? progressBar->show() : progressBar->hide();
+                    progressBar->updateProgress(f);
+                });
+            }
+        }
+    }
+}

--- a/tensorvis/tensorvisio/src/processors/vtkreader.cpp
+++ b/tensorvis/tensorvisio/src/processors/vtkreader.cpp
@@ -39,6 +39,7 @@
 #include <warn/pop>
 
 #include <fstream>
+#include <modules/tensorvisio/util/vtkutil.h>
 
 namespace inviwo {
 
@@ -141,24 +142,9 @@ void VTKReader::readLegacy() {
     dispatchPool([this]() {
         dispatchFront([this]() { getActivityIndicator().setActive(true); });
 
-        const auto progressUpdate = [this](float f) {
-            dispatchFront([this, f]() {
-                f < 1.0 ? progressBar_.show() : progressBar_.hide();
-                progressBar_.updateProgress(f);
-            });
-        };
-
-        auto fn = fnptr<void(vtkObject*, long unsigned int, void*, void*)>(
-            [progressUpdate](vtkObject* caller, long unsigned int /*eventId*/, void* /*clientData*/,
-                             void* /*callData*/) -> void {
-                auto reader = dynamic_cast<vtkGenericDataObjectReader*>(caller);
-                if (reader->GetProgress() > 0.0) {
-                    progressUpdate(float(reader->GetProgress()));
-                }
-            });
-
         auto progressCallback = vtkSmartPointer<vtkCallbackCommand>::New();
-        progressCallback->SetCallback(fn);
+        progressCallback->SetCallback(vtkProgressBarCallback);
+        progressCallback->SetClientData(&progressBar_);
 
         if (!legacyreader_) {
             legacyreader_ = vtkSmartPointer<vtkGenericDataObjectReader>::New();
@@ -182,24 +168,9 @@ void VTKReader::readXML() {
     dispatchPool([this]() {
         dispatchFront([this]() { getActivityIndicator().setActive(true); });
 
-        const auto progressUpdate = [this](float f) {
-            dispatchFront([this, f]() {
-                f < 1.0 ? progressBar_.show() : progressBar_.hide();
-                progressBar_.updateProgress(f);
-            });
-        };
-
-        auto fn = fnptr<void(vtkObject*, long unsigned int, void*, void*)>(
-            [progressUpdate](vtkObject* caller, long unsigned int /*eventId*/, void* /*clientData*/,
-                             void* /*callData*/) -> void {
-                auto reader = dynamic_cast<vtkXMLGenericDataObjectReader*>(caller);
-                if (reader->GetProgress() > 0.0) {
-                    progressUpdate(float(reader->GetProgress()));
-                }
-            });
-
         auto progressCallback = vtkSmartPointer<vtkCallbackCommand>::New();
-        progressCallback->SetCallback(fn);
+        progressCallback->SetCallback(vtkProgressBarCallback);
+        progressCallback->SetClientData(&progressBar_);
 
         if (!xmlreader_) {
             xmlreader_ = vtkSmartPointer<vtkXMLGenericDataObjectReader>::New();


### PR DESCRIPTION
Instead of using the hack that masks the lamdas as function pointers, an actual function pointer is now handed in as callback. The client data for this callback is set separately. Documentation with example usage has been added.