### PR TITLE
Feature/molvis largepdbfiles

### DIFF
--- a/molvis/molvisbase/include/inviwo/molvisbase/datastructures/molecularstructure.h
+++ b/molvis/molvisbase/include/inviwo/molvisbase/datastructures/molecularstructure.h
@@ -56,6 +56,7 @@ namespace molvis {
  */
 struct IVW_MODULE_MOLVISBASE_API Atoms {
     std::vector<dvec3> positions;
+    std::vector<int> serialNumbers;
     std::vector<double> bFactors;  //<!  Debye-Waller factor (DWF) or temperature factor.
     std::vector<int> modelIds;
     std::vector<int> chainIds;

--- a/molvis/molvisbase/include/inviwo/molvisbase/io/basicpdbreader.h
+++ b/molvis/molvisbase/include/inviwo/molvisbase/io/basicpdbreader.h
@@ -40,6 +40,9 @@ namespace inviwo {
  * \ingroup dataio
  *
  * Basic reader for Protein Databank (PDB) files. Will only interpret ATOM and HETATM data.
+ * To support large PDB files, atom serial numbers > 99,999 and residue IDs > 9,999 are interpreted
+ * as hexadecimal numbers. This enables support for files generated for example by VMD, but is
+ * non-standard behavior.
  *
  * \see https://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ATOM
  */

--- a/molvis/molvisbase/src/datastructures/molecularstructure.cpp
+++ b/molvis/molvisbase/src/datastructures/molecularstructure.cpp
@@ -247,6 +247,12 @@ void verifyData(const MolecularData& data) {
     // attributes of atoms in MolecularData can be either empty or must match the number of atoms
     auto sizeValid = [atomCount](const auto& v) { return (v.empty() || (v.size() == atomCount)); };
 
+    if (!sizeValid(data.atoms.serialNumbers)) {
+        throw Exception(
+            fmt::format("Inconsistent MolecularData: expected {} serial numbers, found {}",
+                        atomCount, data.atoms.serialNumbers.size()),
+            IVW_CONTEXT_CUSTOM("MolecularStructure::MolecularStructure()"));
+    }
     if (!sizeValid(data.atoms.bFactors)) {
         throw Exception(fmt::format("Inconsistent MolecularData: expected {} b Factors, found {}",
                                     atomCount, data.atoms.bFactors.size()),

--- a/molvis/molvispython/bindings/src/pymolvis.cpp
+++ b/molvis/molvispython/bindings/src/pymolvis.cpp
@@ -335,6 +335,7 @@ void exposeMolVis(pybind11::module& m) {
     py::class_<Atoms, std::shared_ptr<Atoms>>(m, "Atoms")
         .def(py::init())
         .def_readwrite("positions", &Atoms::positions)
+        .def_readwrite("serialNumbers", &Atoms::serialNumbers)
         .def_readwrite("bfactors", &Atoms::bFactors)
         .def_readwrite("modelids", &Atoms::modelIds)
         .def_readwrite("chainids", &Atoms::chainIds)
@@ -344,10 +345,11 @@ void exposeMolVis(pybind11::module& m) {
         .def("__len__", [](Atoms& a) { return a.positions.size(); })
         .def("__repr__", [](Atoms& a) {
             return fmt::format(
-                "<Atoms: {} positions, {} b Factors, {} model IDs, {} chain IDs, {} residue IDs, "
+                "<Atoms: {} positions, {} serial numbers, {} b factors, {} model IDs, {} chain "
+                "IDs, {} residue IDs, "
                 "{} atomic numbers, {} full names>",
-                a.positions.size(), a.bFactors.size(), a.modelIds.size(), a.chainIds.size(),
-                a.residueIds.size(), a.atomicNumbers.size(), a.fullNames.size());
+                a.positions.size(), a.serialNumbers.size(), a.bFactors.size(), a.modelIds.size(),
+                a.chainIds.size(), a.residueIds.size(), a.atomicNumbers.size(), a.fullNames.size());
         });
 
     py::class_<Residue, std::shared_ptr<Residue>>(m, "Residue")

--- a/molvis/molvispython/python/processors/MolecularStructureSource.py
+++ b/molvis/molvispython/python/processors/MolecularStructureSource.py
@@ -37,6 +37,8 @@ import ivwmolvis
 from Bio.PDB.MMCIFParser import MMCIFParser
 from Bio.PDB.PDBParser import PDBParser
 
+import xpdb
+
 import numpy as np
 
 
@@ -86,7 +88,7 @@ class MolecularStructureSource(ivw.Processor):
             ext = filename.split(".")[-2]
 
         if (ext.startswith('pdb')):
-            parser = PDBParser(PERMISSIVE=1)
+            parser = PDBParser(PERMISSIVE=1, structure_builder=xpdb.SloppyStructureBuilder())
         elif (ext.startswith('cif')):
             parser = MMCIFParser()
         else:
@@ -96,6 +98,7 @@ class MolecularStructureSource(ivw.Processor):
         structure = parser.get_structure(structureName, filename)
 
         pos = []
+        serialNumbers = []
         bfactors = []
         modelId = []
         chainId = []
@@ -110,6 +113,7 @@ class MolecularStructureSource(ivw.Processor):
         for atom in structure.get_atoms():
             structureid, modelid, chainid, resid, _ = atom.get_full_id()
             pos.append(atom.coord)
+            serialNumbers.append(atom.get_serial_number())
             bfactors.append(atom.get_bfactor())
             if modelid not in modelDict:
                 modelDict[modelid] = len(modelDict)
@@ -131,6 +135,7 @@ class MolecularStructureSource(ivw.Processor):
         for p in pos:
             dvec3pos.append(ivw.glm.dvec3(p[0], p[1], p[2]))
         atoms.positions = dvec3pos
+        atoms.serialNumbers = serialNumbers
         atoms.bfactors = bfactors
         atoms.modelids = modelId
         atoms.chainids = chainId

--- a/molvis/molvispython/python/xpdb.py
+++ b/molvis/molvispython/python/xpdb.py
@@ -1,0 +1,156 @@
+# xpdb.py -- extensions to Bio.PDB
+# (c) 2009 Oliver Beckstein
+# Relased under the same license as Biopython.
+# See http://biopython.org/wiki/Reading_large_PDB_files
+
+import sys
+import Bio.PDB
+import Bio.PDB.StructureBuilder
+from Bio.PDB.Residue import Residue
+
+
+class SloppyStructureBuilder(Bio.PDB.StructureBuilder.StructureBuilder):
+    """Cope with resSeq < 10,000 limitation by just incrementing internally.
+
+    # Q: What's wrong here??
+    #   Some atoms or residues will be missing in the data structure.
+    #   WARNING: Residue (' ', 8954, ' ') redefined at line 74803.
+    #   PDBConstructionException: Blank altlocs in duplicate residue SOL
+    #   (' ', 8954, ' ') at line 74803.
+    #
+    # A: resSeq only goes to 9999 --> goes back to 0 (PDB format is not really
+    #    good here)
+    """
+
+    # NOTE/TODO:
+    # - H and W records are probably not handled yet (don't have examples
+    #   to test)
+
+    def __init__(self, verbose=False):
+        Bio.PDB.StructureBuilder.StructureBuilder.__init__(self)
+        self.max_resseq = -1
+        self.verbose = verbose
+
+    def init_residue(self, resname, field, resseq, icode):
+        """Initiate a new Residue object.
+
+        Arguments:
+        o resname - string, e.g. "ASN"
+        o field - hetero flag, "W" for waters, "H" for
+            hetero residues, otherwise blanc.
+        o resseq - int, sequence identifier
+        o icode - string, insertion code
+
+        """
+        if field != " ":
+            if field == "H":
+                # The hetero field consists of
+                # H_ + the residue name (e.g. H_FUC)
+                field = "H_" + resname
+        res_id = (field, resseq, icode)
+
+        if resseq > self.max_resseq:
+            self.max_resseq = resseq
+
+        if field == " ":
+            fudged_resseq = False
+            while self.chain.has_id(res_id) or resseq == 0:
+                # There already is a residue with the id (field, resseq, icode)
+                # resseq == 0 catches already wrapped residue numbers which
+                # do not trigger the has_id() test.
+                #
+                # Be sloppy and just increment...
+                # (This code will not leave gaps in resids... I think)
+                #
+                # XXX: shouldn't we also do this for hetero atoms and water??
+                self.max_resseq += 1
+                resseq = self.max_resseq
+                res_id = (field, resseq, icode)  # use max_resseq!
+                fudged_resseq = True
+
+            if fudged_resseq and self.verbose:
+                sys.stderr.write(
+                    "Residues are wrapping (Residue "
+                    + "('%s', %i, '%s') at line %i)."
+                    % (field, resseq, icode, self.line_counter)
+                    + ".... assigning new resid %d.\n" % self.max_resseq
+                )
+        residue = Residue(res_id, resname, self.segid)
+        self.chain.add(residue)
+        self.residue = residue
+
+
+class SloppyPDBIO(Bio.PDB.PDBIO):
+    """PDBIO class that can deal with large pdb files as used in MD simulations
+
+    - resSeq simply wrap and are printed modulo 10,000.
+    - atom numbers wrap at 99,999 and are printed modulo 100,000
+
+    """
+
+    # The format string is derived from the PDB format as used in PDBIO.py
+    # (has to be copied to the class because of the package layout it is not
+    # externally accessible)
+    _ATOM_FORMAT_STRING = (
+        "%s%5i %-4s%c%3s %c%4i%c   " + "%8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n"
+    )
+
+    def _get_atom_line(
+        self,
+        atom,
+        hetfield,
+        segid,
+        atom_number,
+        resname,
+        resseq,
+        icode,
+        chain_id,
+        element="  ",
+        charge="  ",
+    ):
+        """ Returns an ATOM string that is guaranteed to fit the ATOM format.
+
+        - Resid (resseq) is wrapped (modulo 10,000) to fit into %4i (4I) format
+        - Atom number (atom_number) is wrapped (modulo 100,000) to fit into
+          %5i (5I) format
+
+        """
+        if hetfield != " ":
+            record_type = "HETATM"
+        else:
+            record_type = "ATOM  "
+        name = atom.get_fullname()
+        altloc = atom.get_altloc()
+        x, y, z = atom.get_coord()
+        bfactor = atom.get_bfactor()
+        occupancy = atom.get_occupancy()
+        args = (
+            record_type,
+            atom_number % 100000,
+            name,
+            altloc,
+            resname,
+            chain_id,
+            resseq % 10000,
+            icode,
+            x,
+            y,
+            z,
+            occupancy,
+            bfactor,
+            segid,
+            element,
+            charge,
+        )
+        return self._ATOM_FORMAT_STRING % args
+
+
+# convenience functions
+
+sloppyparser = Bio.PDB.PDBParser(
+    PERMISSIVE=True, structure_builder=SloppyStructureBuilder()
+)
+
+
+def get_structure(pdbfile, pdbid="system"):
+    return sloppyparser.get_structure(pdbid, pdbfile)


### PR DESCRIPTION
PDB files officially support only up to 99,999 atoms and 9,999 residues. This fix adds support for larger files, e.g. generated by VMD which use hexadecimal indices beyond 100,000.