### PR TITLE
Fix TTK's boost target

### DIFF
--- a/topovis/topologytoolkit/CMakeLists.txt
+++ b/topovis/topologytoolkit/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Boost is required by TTK
-find_package(Boost COMPONENTS ALL REQUIRED)
+find_package(Boost COMPONENTS system REQUIRED)
 
 #TBB is required for parallel STL used in separatrix relaxation processor
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
Thanks to @ResearchDaniel, I've looked at which boost libraries are actually necessary (which is only  `system`). Cmake runs through and everything compiles now.