### PR TITLE
netcdf: Fix python error

### DIFF
--- a/misc/netcdf/CMakeLists.txt
+++ b/misc/netcdf/CMakeLists.txt
@@ -2,7 +2,9 @@
 # Inviwo netcdf Module
 ivw_module(NetCDF)
 
-#Check if netCDF4 python module exist
+# Code uses type hinting generics in standard collections (new in 3.9)
+find_package(Python3 3.9 REQUIRED)
+# Check if netCDF4 python module exist
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
              "try: import netCDF4; print(netCDF4.__version__);\nexcept: print('\tFailed to import NetCDF4 python package. Run pip install NetCDF4')\n"
               RESULT_VARIABLE NETCDF_STATUS

--- a/misc/netcdf/python/genericnetcdfsource.py
+++ b/misc/netcdf/python/genericnetcdfsource.py
@@ -63,7 +63,7 @@ class GenericNetCDFSource(ivw.Processor):
             minmax.visible = False  # Only show when a corresponding variable is enabled
             self.dimensions.addProperty(minmax, True)
 
-    def addMinMaxProperties(self, dims: list[Dimension]):
+    def addMinMaxProperties(self, dims: [Dimension]):
         for dim in dims:
             self.addMinmaxProperty(dim)
 

--- a/misc/netcdf/python/genericnetcdfsource.py
+++ b/misc/netcdf/python/genericnetcdfsource.py
@@ -63,7 +63,7 @@ class GenericNetCDFSource(ivw.Processor):
             minmax.visible = False  # Only show when a corresponding variable is enabled
             self.dimensions.addProperty(minmax, True)
 
-    def addMinMaxProperties(self, dims: [Dimension]):
+    def addMinMaxProperties(self, dims: list[Dimension]):
         for dim in dims:
             self.addMinmaxProperty(dim)
 

--- a/misc/netcdf/readme.md
+++ b/misc/netcdf/readme.md
@@ -7,6 +7,8 @@ To install the python NetCDF4 dependency run `pip install netcdf4`.
 
 ### Requires Python 3.9
 For reference (in case you cannot upgrade to Python 3.9):
-Another solution is to import the typing library in genericnetcdfsource.py:
+Another solution is to import the `typing` library in genericnetcdfsource.py:
+```python
 from typing import List
-and replace list[Dimension] with List[Dimension].
+```
+and replace `list[Dimension]` with `List[Dimension]`.

--- a/misc/netcdf/readme.md
+++ b/misc/netcdf/readme.md
@@ -4,3 +4,9 @@ Utilities for loading and handling NetCDF data. The module relies on the python 
 Nested variables in groups are not supported so far.
 
 To install the python NetCDF4 dependency run `pip install netcdf4`.
+
+### Requires Python 3.9
+For reference (in case you cannot upgrade to Python 3.9):
+Another solution is to import the typing library in genericnetcdfsource.py:
+from typing import List
+and replace list[Dimension] with List[Dimension].


### PR DESCRIPTION
Error(s) occur when using the following setup:
Anaconda 3, Python version: 3.8.5 (default, Sep  3 2020, 21:29:08) [MSC v.1916 64 bit (AMD64)]

Error reloading file: C:/inviwo/modules/misc/netcdf/python/processors/netcdfvolumesource.py Message:
Failed to load processor NetCDFVolumeSource from script: C:/inviwo/modules/misc/netcdf/python/processors/netcdfvolumesource.py.
TypeError: 'type' object is not subscriptable

At:
  C:/inviwo/modules/misc/netcdf/python\genericnetcdfsource.py(66): GenericNetCDFSource
  C:/inviwo/modules/misc/netcdf/python\genericnetcdfsource.py(11): <module>
  <frozen importlib._bootstrap>(219): _call_with_frames_removed
  <frozen importlib._bootstrap_external>(783): exec_module
  <frozen importlib._bootstrap>(609): _exec
  C:\Users\danjo\Anaconda3\Lib\importlib\__init__.py(176): reload
  <string>(11): <module>