### PR TITLE
Added feature level-sets and dependencies

### DIFF
--- a/.github/presets/common.json
+++ b/.github/presets/common.json
@@ -32,6 +32,8 @@
         "IVW_MODULE_TENSORVISIO":           { "type": "BOOL", "value": "ON"},
         "IVW_MODULE_TENSORVISPYTHON":       { "type": "BOOL", "value": "ON"},
         "IVW_MODULE_INTEGRALLINEFILTERING": { "type": "BOOL", "value": "ON"},
+        "IVW_MODULE_FEATURELEVELSETSGL":    { "type": "BOOL", "value": "ON"},
+        "IVW_MODULE_COMPUTEUTILS":          { "type": "BOOL", "value": "ON"},
         "IVW_MODULE_MOLVISBASE":            { "type": "BOOL", "value": "ON"},
         "IVW_MODULE_MOLVISGL":              { "type": "BOOL", "value": "ON"},
         "IVW_MODULE_MOLVISPYTHON":          { "type": "BOOL", "value": "ON"},

--- a/misc/computeutils/CMakeLists.txt
+++ b/misc/computeutils/CMakeLists.txt
@@ -1,0 +1,50 @@
+ivw_module(ComputeUtils)
+
+set(HEADER_FILES
+    include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
+    include/inviwo/computeutils/algorithm/volumeminmaxgl.h
+    include/inviwo/computeutils/algorithm/volumenormalizationgl.h
+    include/inviwo/computeutils/algorithm/volumereductiongl.h
+    include/inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h
+    include/inviwo/computeutils/computeutilsmodule.h
+    include/inviwo/computeutils/computeutilsmoduledefine.h
+    include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
+    include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
+    include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
+    include/inviwo/computeutils/processors/volumereductionglprocessor.h
+    include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
+)
+ivw_group("Header Files" ${HEADER_FILES})
+
+set(SOURCE_FILES
+    src/algorithm/volumechannelsplitgl.cpp
+    src/algorithm/volumeminmaxgl.cpp
+    src/algorithm/volumenormalizationgl.cpp
+    src/algorithm/volumereductiongl.cpp
+    src/algorithm/volumeshrinktonormalrangegl.cpp
+    src/computeutilsmodule.cpp
+    src/processors/volumechannelsplitglprocessor.cpp
+    src/processors/volumeminmaxglprocessor.cpp
+    src/processors/volumenormalizationglprocessor.cpp
+    src/processors/volumereductionglprocessor.cpp
+    src/processors/volumeshrinktonormalrangeglprocessor.cpp
+)
+ivw_group("Source Files" ${SOURCE_FILES})
+
+set(SHADER_FILES
+	${CMAKE_CURRENT_SOURCE_DIR}/glsl/volumesplit.comp
+	${CMAKE_CURRENT_SOURCE_DIR}/glsl/volumereduction.comp
+    ${CMAKE_CURRENT_SOURCE_DIR}/glsl/volumenormalization.comp
+    ${CMAKE_CURRENT_SOURCE_DIR}/glsl/volumeshrinktonormalrange.comp
+)
+ivw_group("Shader Files" ${SHADER_FILES})
+
+set(TEST_FILES
+    tests/unittests/computeutils-unittest-main.cpp
+)
+ivw_add_unittest(${TEST_FILES})
+
+ivw_create_module(${SOURCE_FILES} ${HEADER_FILES} ${SHADER_FILES})
+
+# Add shader directory to install package
+#ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/glsl)

--- a/misc/computeutils/CMakeLists.txt
+++ b/misc/computeutils/CMakeLists.txt
@@ -46,5 +46,4 @@ ivw_add_unittest(${TEST_FILES})
 
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES} ${SHADER_FILES})
 
-# Add shader directory to install package
-#ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/glsl)
+ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/glsl)

--- a/misc/computeutils/depends.cmake
+++ b/misc/computeutils/depends.cmake
@@ -1,0 +1,3 @@
+set(dependencies
+    InviwoOpenGLModule
+)

--- a/misc/computeutils/glsl/volumenormalization.comp
+++ b/misc/computeutils/glsl/volumenormalization.comp
@@ -36,8 +36,8 @@ writeonly uniform image3D outputTexture;
 layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 vec4 getNormalizedVoxel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos) {
-    return (texelFetch(volume, samplePos, 0) + volumeParams.formatOffset)
-        * (1.0 - volumeParams.formatScaling);
+    return (texelFetch(volume, samplePos, 0) - volumeParams.texToNormalized.offset)
+        * volumeParams.texToNormalized.scaling;
 }
 
 float getNormalizedVoxelChannel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos, int channel) {

--- a/misc/computeutils/glsl/volumenormalization.comp
+++ b/misc/computeutils/glsl/volumenormalization.comp
@@ -1,0 +1,80 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2014-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ *********************************************************************************/
+
+#include "utils/structs.glsl"
+
+uniform sampler3D inputTexture;
+uniform VolumeParameters inputTextureParameters;
+writeonly uniform image3D outputTexture;
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+vec4 getNormalizedVoxel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos) {
+    return (texelFetch(volume, samplePos, 0) + volumeParams.formatOffset)
+        * (1.0 - volumeParams.formatScaling);
+}
+
+float getNormalizedVoxelChannel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos, int channel) {
+    vec4 v = getNormalizedVoxel(volume, volumeParams, samplePos);
+    return v[channel];
+}
+
+void main() {
+    ivec3 samplePos = ivec3(gl_GlobalInvocationID);
+
+    vec4 original = texelFetch(inputTexture, samplePos, 0);
+    
+    float l, m, n, o;
+
+#ifdef NORMALIZE_CHANNEL_0
+    l = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 0);
+#else
+    l = original[0];
+#endif
+
+#ifdef NORMALIZE_CHANNEL_1
+    m = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 1);
+#else
+    m  = original[1];
+#endif
+
+#ifdef NORMALIZE_CHANNEL_2
+    n = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 2);
+#else
+    n = original[2];
+#endif
+
+#ifdef NORMALIZE_CHANNEL_3
+    o = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 3);
+#else
+    o = original[3];
+#endif
+
+    imageStore(outputTexture, samplePos, vec4(l, m, n, o));
+}

--- a/misc/computeutils/glsl/volumenormalization.comp
+++ b/misc/computeutils/glsl/volumenormalization.comp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2021 Inviwo Foundation
+ * Copyright (c) 2014-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/glsl/volumereduction.comp
+++ b/misc/computeutils/glsl/volumereduction.comp
@@ -1,0 +1,218 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+uniform
+#if defined REDUCTION_SAMPLER_TYPE_FLOAT
+ sampler3D 
+#elif defined REDUCTION_SAMPLER_TYPE_INTEGER
+ isampler3D 
+#elif defined REDUCTION_SAMPLER_TYPE_UNSIGNED
+ usampler3D 
+#endif
+inputTexture;
+
+uniform vec2 disregardingRange;
+
+writeonly uniform image3D outputTexture;
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+void main() {
+    ivec3 outputPosition = ivec3(gl_GlobalInvocationID);
+    ivec3 samplePosition000 = outputPosition * ivec3(2, 2, 2);
+    ivec3 samplePosition001 = samplePosition000 + ivec3(0, 0, 1);
+    ivec3 samplePosition010 = samplePosition000 + ivec3(0, 1, 0);
+    ivec3 samplePosition011 = samplePosition000 + ivec3(0, 1, 1);
+    ivec3 samplePosition100 = samplePosition000 + ivec3(1, 0, 0);
+    ivec3 samplePosition101 = samplePosition000 + ivec3(1, 0, 1);
+    ivec3 samplePosition110 = samplePosition000 + ivec3(1, 1, 0);
+    ivec3 samplePosition111 = samplePosition000 + ivec3(1, 1, 1);
+    
+    vec4 val = vec4(0);
+    vec4 sampledVal = vec4(0);
+    bool less = false;
+    bool greater = false;
+    vec4 disregardingRangeMin = vec4(disregardingRange.x);
+    vec4 disregardingRangeMax = vec4(disregardingRange.y);
+
+// Min operator
+#if OPERATOR == 0
+    // Init with infinity
+    val = vec4(1.0 / 0.0);
+    
+
+    sampledVal = texelFetch(inputTexture, samplePosition000, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition001, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition010, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition011, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition100, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition101, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition110, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition111, 0);
+#if DISREGARD == 1
+    less = any(lessThan(sampledVal, disregardingRangeMin));
+    val = less ? val : min(val, sampledVal);
+#else
+    val = min(val, sampledVal);
+#endif
+#endif
+
+// Max operator
+#if OPERATOR == 1
+    // Init with -infinity
+    val = vec4(-1.0 / 0.0);
+    
+    sampledVal = texelFetch(inputTexture, samplePosition000, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition001, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition010, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition011, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition100, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition101, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition110, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+
+    sampledVal = texelFetch(inputTexture, samplePosition111, 0);
+#if DISREGARD == 1
+    greater = any(greaterThan(sampledVal, disregardingRangeMax));
+    val = greater ? val : max(val, sampledVal);
+#else
+    val = max(val, sampledVal);
+#endif
+#endif
+
+// Sum operator
+#if OPERATOR == 2
+    val = texelFetch(inputTexture, samplePosition000, 0);
+    val = val + texelFetch(inputTexture, samplePosition001, 0);
+    val = val + texelFetch(inputTexture, samplePosition010, 0);
+    val = val + texelFetch(inputTexture, samplePosition011, 0);
+    val = val + texelFetch(inputTexture, samplePosition100, 0);
+    val = val + texelFetch(inputTexture, samplePosition101, 0);
+    val = val + texelFetch(inputTexture, samplePosition110, 0);
+    val = val + texelFetch(inputTexture, samplePosition111, 0);
+#endif
+
+    imageStore (outputTexture, outputPosition, val);
+}

--- a/misc/computeutils/glsl/volumereduction.comp
+++ b/misc/computeutils/glsl/volumereduction.comp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/glsl/volumeshrinktonormalrange.comp
+++ b/misc/computeutils/glsl/volumeshrinktonormalrange.comp
@@ -37,8 +37,8 @@ uniform float offset;
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 vec4 getNormalizedVoxel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos) {
-    return (texelFetch(volume, samplePos, 0) + volumeParams.formatOffset) *
-           (1.0 - volumeParams.formatScaling);
+    return (texelFetch(volume, samplePos, 0) - volumeParams.texToNormalized.offset) *
+           volumeParams.texToNormalized.scaling;
 }
 
 float getNormalizedVoxelChannel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos,

--- a/misc/computeutils/glsl/volumeshrinktonormalrange.comp
+++ b/misc/computeutils/glsl/volumeshrinktonormalrange.comp
@@ -1,0 +1,82 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2014-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include "utils/structs.glsl"
+
+uniform sampler3D inputTexture;
+uniform VolumeParameters inputTextureParameters;
+writeonly uniform image3D outputTexture;
+uniform float offset;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+vec4 getNormalizedVoxel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos) {
+    return (texelFetch(volume, samplePos, 0) + volumeParams.formatOffset) *
+           (1.0 - volumeParams.formatScaling);
+}
+
+float getNormalizedVoxelChannel(sampler3D volume, VolumeParameters volumeParams, ivec3 samplePos,
+                                int channel) {
+    vec4 v = getNormalizedVoxel(volume, volumeParams, samplePos);
+    return v[channel];
+}
+
+void main() {
+    ivec3 samplePos = ivec3(gl_GlobalInvocationID);
+
+    vec4 original = texelFetch(inputTexture, samplePos, 0);
+
+    float l, m, n, o;
+
+#ifdef SHRINK_CHANNEL_0
+    l = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 0) + offset;
+#else
+    l = original[0];
+#endif
+
+#ifdef SHRINK_CHANNEL_1
+    m = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 1) + offset;
+#else
+    m = original[1];
+#endif
+
+#ifdef SHRINK_CHANNEL_2
+    n = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 2) + offset;
+#else
+    n = original[2];
+#endif
+
+#ifdef SHRINK_CHANNEL_3
+    o = getNormalizedVoxelChannel(inputTexture, inputTextureParameters, samplePos, 3) + offset;
+#else
+    o = original[3];
+#endif
+
+    imageStore(outputTexture, samplePos, vec4(l, m, n, o));
+}

--- a/misc/computeutils/glsl/volumeshrinktonormalrange.comp
+++ b/misc/computeutils/glsl/volumeshrinktonormalrange.comp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2021 Inviwo Foundation
+ * Copyright (c) 2014-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/glsl/volumesplit.comp
+++ b/misc/computeutils/glsl/volumesplit.comp
@@ -1,0 +1,56 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+uniform sampler3D inputTexture;
+
+writeonly uniform image3D outputTexture;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+void main() {
+    ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+    vec4 val = texelFetch(inputTexture, pos, 0);
+
+#if CHANNEL == 0
+    imageStore(outputTexture, pos, vec4(val.x));
+#endif
+
+#if CHANNEL == 1
+    imageStore(outputTexture, pos, vec4(val.y));
+#endif
+
+#if CHANNEL == 2
+    imageStore(outputTexture, pos, vec4(val.z));
+#endif
+
+#if CHANNEL == 3
+    imageStore(outputTexture, pos, vec4(val.w));
+#endif
+}

--- a/misc/computeutils/glsl/volumesplit.comp
+++ b/misc/computeutils/glsl/volumesplit.comp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
@@ -1,0 +1,67 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/computeutils/algorithm/volumereductiongl.h>
+
+namespace inviwo {
+/** \class VolumeChannelSplitGL
+ *
+ * Splits multi-channel volumes into several single-channel volumes.
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeChannelSplitGL {
+public:
+    template <typename Callback>
+    VolumeChannelSplitGL(Callback C) : VolumeChannelSplitGL() {
+        shader_.onReload(C);
+    }
+
+    VolumeChannelSplitGL();
+
+    virtual ~VolumeChannelSplitGL() = default;
+
+    /**
+     * Splits multi-channel volumes into several single-channel volumes
+     *
+     * @param volume Volume to be split.
+     * @return Set of single-channel volumes
+     */
+    std::vector<std::shared_ptr<Volume>> split(std::shared_ptr<const Volume> volume);
+
+protected:
+    Shader shader_;
+
+    VolumeReductionGL volumeReductionGl_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
@@ -56,7 +56,7 @@ public:
      * @param volume Volume to be split.
      * @return Set of single-channel volumes
      */
-    std::vector<std::shared_ptr<Volume>> split(std::shared_ptr<const Volume> volume);
+    VolumeSequence split(std::shared_ptr<const Volume> volume);
 
 protected:
     Shader shader_;

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumechannelsplitgl.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
@@ -58,7 +58,7 @@ public:
      * the max value. In addition, you know that outliers are marked with a value of INT_MAX so you
      * would like those values to not be considered. In that case, you call
      * minmax(myVolume, DisregardingStatus::On,
-     *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
+     *        vec2{myVolume->dataMap.dataRange.x, std::numeric_limits<int>::max() - 1});
      * @param range The range that should be disregarded.
      *
      * @returns Aggregated min/max values.

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
@@ -1,0 +1,73 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/computeutils/algorithm/volumereductiongl.h>
+
+namespace inviwo {
+
+/** \class VolumeMinMaxGL
+ *
+ * GL implementation of min-max computation for inviwo volumes.
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeMinMaxGL {
+public:
+    VolumeMinMaxGL() = default;
+
+    virtual ~VolumeMinMaxGL() = default;
+
+    /**
+     * This method calculates min and max values of a volume. If you need min/max per
+     * channel you should look at VolumeReductionGL.
+     *
+     * @param volume Input volume.
+     * @param disregardingStatus Indicating whether or not the calculation of the min/max value
+     * should disregard a certain value range. This is for example handy for volumes where special
+     * regions are marked with voxel values of INT_MAX or the like.
+     * * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the
+     * max value. In addition, you know that outliers are marked with a value of INT_MAX so you
+     * would like those values to not be considered. In that case, you call
+     * minmax(myVolume, DisregardingStatus::On,
+     *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
+     * @param range The range that should be disregarded.
+     *
+     * @returns Aggregated min/max values.
+     */
+    dvec2 minmax(std::shared_ptr<const Volume> volume,
+                 DisregardingStatus disregardingStatus = DisregardingStatus::Off, const vec2& range = vec2{0});
+
+protected:
+    VolumeReductionGL volumeReductionGL_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
@@ -54,8 +54,8 @@ public:
      * @param disregardingStatus Indicating whether or not the calculation of the min/max value
      * should disregard a certain value range. This is for example handy for volumes where special
      * regions are marked with voxel values of INT_MAX or the like.
-     * * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the
-     * max value. In addition, you know that outliers are marked with a value of INT_MAX so you
+     * * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute
+     * the max value. In addition, you know that outliers are marked with a value of INT_MAX so you
      * would like those values to not be considered. In that case, you call
      * minmax(myVolume, DisregardingStatus::On,
      *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
@@ -64,7 +64,8 @@ public:
      * @returns Aggregated min/max values.
      */
     dvec2 minmax(std::shared_ptr<const Volume> volume,
-                 DisregardingStatus disregardingStatus = DisregardingStatus::Off, const vec2& range = vec2{0});
+                 DisregardingStatus disregardingStatus = DisregardingStatus::Off,
+                 const vec2& range = vec2{0});
 
 protected:
     VolumeReductionGL volumeReductionGL_;

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumeminmaxgl.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumenormalizationgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumenormalizationgl.h
@@ -1,0 +1,93 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+
+namespace inviwo {
+/** \class VolumeNormalizationGL
+ *
+ * GL implementation of volume normalization. The algorithm takes in a volume and normalized its
+ * data in the selected channels to range [0,1].
+ * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
+ * volume in terms of vector norms!
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeNormalizationGL {
+public:
+    template <typename Callback>
+    VolumeNormalizationGL(Callback C) : VolumeNormalizationGL() {
+        shader_.onReload(C);
+    }
+
+    VolumeNormalizationGL();
+
+    virtual ~VolumeNormalizationGL() = default;
+
+    /**
+     * Performs the normalization on the GPU.
+     *
+     * @param volume Input volume to be normalized.
+     * @return A volume whose selected channels have been normalized.
+     */
+    std::shared_ptr<Volume> normalize(const Volume& volume);
+
+    /**
+     * Sets the channel that are to be normalized. In practice, this method in-/ejects shader
+     * defines for every channel.
+     *
+     * @param channel Channel for which the normalization should be set to true or false.
+     * @param normalize Boolean value indicating whether or not the selected channel should be
+     * normalized.
+     */
+    void setNormalizeChannel(size_t channel, bool normalize);
+
+    /**
+     * Sets the channels that are to be normalized. In practice, this method in-/ejects shader
+     * defines for every channel.
+     *
+     * @param normalize Set of boolean values indicating which channels to normalize.
+     */
+    void setNormalizeChannels(bvec4 normalize);
+
+    /**
+     * Resets the normalization settings. Channel 0 is set to true, rest to false.
+     */
+    void reset();
+
+protected:
+    Shader shader_;
+
+private:
+    bool needsCompilation_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumenormalizationgl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumenormalizationgl.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumereductiongl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumereductiongl.h
@@ -1,0 +1,113 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+
+namespace inviwo {
+enum class ReductionOperator { Min = 0, Max = 1, Sum = 2, None = 3 };
+enum class DisregardingStatus { Off = 0, On = 1, Unset = 2 };
+
+/** \class VolumeReductionGL
+ *
+ * GL implementation of add, min, and max reductions for 3D textures (volumes).
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeReductionGL {
+public:
+    template <typename Callback>
+    VolumeReductionGL(Callback C) : VolumeReductionGL() {
+        shader_.onReload(C);
+    }
+
+    VolumeReductionGL();
+
+    virtual ~VolumeReductionGL() = default;
+
+    /**
+     * This method calculates and returns the reduced volume (dimensions 1x1x1) according to the
+     * operator, i.e. min/max/sum.
+     *
+     * @param volume Input volume.
+     * @param op Reduction operator that is applied to calculate the reduced value, i.e.
+     * min/max/sum.
+     * @param disregardingStatus Indicating whether or not the calculation of the min/max/sum value
+     * should disregard a certain value range. This is for example handy for volumes where special
+     * regions are marked with voxel values of INT_MAX or the like.
+     * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the
+     * max value. In addition, you know that outliers are marked with a value of INT_MAX so you
+     * would like those values to not be considered. In that case, you call
+     * reduce(myVolume, ReductionOperator::Max, DisregardingStatus::On,
+     *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
+     * @param range The range that should be disregarded.
+     *
+     * @returns Reduced volume (dimensions 1x1x1) according to selected operator.
+     */
+    std::shared_ptr<Volume> reduce(std::shared_ptr<const Volume> volume, ReductionOperator op,
+                                   DisregardingStatus disregardingStatus = DisregardingStatus::Off,
+                                   const vec2& range = vec2{0});
+
+    /**
+     * This method calculates and returns the reduced value according to the operator, i.e.
+     * min/max/sum.
+     *
+     * @param volume Input volume.
+     * @param op Reduction operator that is applied to calculate the reduced value, i.e.
+     * min/max/sum.
+     * @param disregardingStatus Indicating whether or not the calculation of the min/max/sum value
+     * should be clamped to a certain range. This is for example handy for volumes where special
+     * regions are marked with voxel values of INT_MAX or the like.
+     * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the
+     * max value. In addition, you know that outliers are marked with a value of INT_MAX so you
+     * would like those values to not be considered. In that case, you call
+     * reduce(myVolume, ReductionOperator::Max, DisregardingStatus::On,
+     *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
+     * @param range The range that should be disregarded.
+     *
+     * @returns Reduced value according to selected operator.
+     */
+    double reduce_v(std::shared_ptr<const Volume> volume, ReductionOperator op,
+                    DisregardingStatus disregardingStatus = DisregardingStatus::Off,
+                    const vec2& range = vec2{0});
+
+protected:
+    Shader shader_;
+    ReductionOperator activeReductionOperator_;
+    DisregardingStatus activeDisregardingStatus_;
+
+private:
+    void setReductionOperator(ReductionOperator op);
+    void setDisregarding(DisregardingStatus disregardingStatus);
+    void setSamplerType(std::shared_ptr<const Volume> volume);
+    static void gpuDispatch(GLuint x, GLuint y, GLuint z);
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumereductiongl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumereductiongl.h
@@ -30,12 +30,43 @@
 #pragma once
 
 #include <inviwo/computeutils/computeutilsmoduledefine.h>
-#include <modules/opengl/shader/shader.h>
 #include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/util/exception.h>
+#include <modules/opengl/shader/shader.h>
 
 namespace inviwo {
 enum class ReductionOperator { Min = 0, Max = 1, Sum = 2, None = 3 };
 enum class DisregardingStatus { Off = 0, On = 1, Unset = 2 };
+
+constexpr std::string_view format_as(ReductionOperator op) {
+    using enum ReductionOperator;
+    switch (op) {
+        case Min:
+            return "min";
+        case Max:
+            return "max";
+        case Sum:
+            return "sum";
+        case None:
+            return "none";
+        default:
+            throw Exception{"Invalid enum value"};
+    }
+}
+
+constexpr std::string_view format_as(DisregardingStatus op) {
+    using enum DisregardingStatus;
+    switch (op) {
+        case Off:
+            return "off";
+        case On:
+            return "on";
+        case Unset:
+            return "unset";
+        default:
+            throw Exception{"Invalid enum value"};
+    }
+}
 
 /** \class VolumeReductionGL
  *
@@ -44,7 +75,7 @@ enum class DisregardingStatus { Off = 0, On = 1, Unset = 2 };
 class IVW_MODULE_COMPUTEUTILS_API VolumeReductionGL {
 public:
     template <typename Callback>
-    VolumeReductionGL(Callback C) : VolumeReductionGL() {
+    explicit VolumeReductionGL(Callback C) : VolumeReductionGL() {
         shader_.onReload(C);
     }
 
@@ -59,14 +90,14 @@ public:
      * @param volume Input volume.
      * @param op Reduction operator that is applied to calculate the reduced value, i.e.
      * min/max/sum.
-     * @param disregardingStatus Indicating whether or not the calculation of the min/max/sum value
-     * should disregard a certain value range. This is for example handy for volumes where special
-     * regions are marked with voxel values of INT_MAX or the like.
-     * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the
-     * max value. In addition, you know that outliers are marked with a value of INT_MAX so you
-     * would like those values to not be considered. In that case, you call
-     * reduce(myVolume, ReductionOperator::Max, DisregardingStatus::On,
-     *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
+     * @param disregardingStatus Indicating whether or not the calculation of the min/max/sum
+     * value should disregard a certain value range. This is for example handy for volumes where
+     * special regions are marked with voxel values of INT_MAX or the like. Example: Your data
+     * array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the max value. In
+     * addition, you know that outliers are marked with a value of INT_MAX so you would like
+     * those values to not be considered. In that case, you call reduce(myVolume,
+     * ReductionOperator::Max, DisregardingStatus::On, vec2{myVolume->dataMap.dataRange.x,
+     * std::numeric_limits<int>::max() - 1});
      * @param range The range that should be disregarded.
      *
      * @returns Reduced volume (dimensions 1x1x1) according to selected operator.
@@ -82,14 +113,14 @@ public:
      * @param volume Input volume.
      * @param op Reduction operator that is applied to calculate the reduced value, i.e.
      * min/max/sum.
-     * @param disregardingStatus Indicating whether or not the calculation of the min/max/sum value
-     * should be clamped to a certain range. This is for example handy for volumes where special
-     * regions are marked with voxel values of INT_MAX or the like.
-     * Example: Your data array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the
-     * max value. In addition, you know that outliers are marked with a value of INT_MAX so you
-     * would like those values to not be considered. In that case, you call
-     * reduce(myVolume, ReductionOperator::Max, DisregardingStatus::On,
-     *        vec2{myVolume->dataMap_.dataRange.x, std::numeric_limits<int>::max() - 1});
+     * @param disregardingStatus Indicating whether or not the calculation of the min/max/sum
+     * value should be clamped to a certain range. This is for example handy for volumes where
+     * special regions are marked with voxel values of INT_MAX or the like. Example: Your data
+     * array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the max value. In
+     * addition, you know that outliers are marked with a value of INT_MAX so you would like
+     * those values to not be considered. In that case, you call reduce(myVolume,
+     * ReductionOperator::Max, DisregardingStatus::On, vec2{myVolume->dataMap.dataRange.x,
+     * std::numeric_limits<int>::max() - 1});
      * @param range The range that should be disregarded.
      *
      * @returns Reduced value according to selected operator.

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumereductiongl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumereductiongl.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h
@@ -1,0 +1,93 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+
+namespace inviwo {
+/** \class VolumeShrinkToNormalRangeGL
+ *
+ * GL implementation of volume shrink operation. The algorithm takes in a volume and shrinks its
+ * data in the selected channels to range [0,1] + offset where offset is the percentual deviation of
+ * the minimum from 0. For example, range [-0.5, 1.0] will be shrunk to [-0.33, 0.66].
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeShrinkToNormalRangeGL {
+public:
+    template <typename Callback>
+    VolumeShrinkToNormalRangeGL(Callback C) : VolumeShrinkToNormalRangeGL() {
+        shader_.onReload(C);
+    }
+
+    VolumeShrinkToNormalRangeGL();
+
+    virtual ~VolumeShrinkToNormalRangeGL() = default;
+
+    /**
+     * Shrinks volume data in the selected channels to range [0,1] + offset where offset is the
+     * percentual deviaton of the minimum from 0. For example, range [-0.5, 1.0] will be shrunk to
+     * [-0.33, 0.66].
+     *
+     * @param volume Input volume to be shrunk.
+     * @return A volume whose selected channels have been shrunk.
+     */
+    std::shared_ptr<Volume> shrink(const Volume& volume);
+
+    /**
+     * Sets the channel that are to be shrunk. In practice, this method in-/ejects shader
+     * defines for every channel.
+     *
+     * @param channel Channel for which the shrinking should be set to true or false.
+     * @param shrink Boolean value indicating whether or not the selected channel should be shrunk.
+     */
+    void setShrinkChannel(size_t channel, bool shrink);
+
+    /**
+     * Sets the channels that are to be shrunk. In practice, this method in-/ejects shader
+     * defines for every channel.
+     *
+     * @param shrink Set of boolean values indicating which channels to shrink.
+     */
+    void setShrinkChannels(bvec4 shrink);
+
+    /**
+     * Resets the skrinking settings. Channel 0 is set to true, rest to false.
+     */
+    void reset();
+
+protected:
+    Shader shader_;
+
+private:
+    bool needsCompilation_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h
+++ b/misc/computeutils/include/inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/computeutilsmodule.h
+++ b/misc/computeutils/include/inviwo/computeutils/computeutilsmodule.h
@@ -1,0 +1,42 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <inviwo/core/common/inviwomodule.h>
+
+namespace inviwo {
+
+class IVW_MODULE_COMPUTEUTILS_API ComputeUtilsModule : public InviwoModule {
+public:
+    ComputeUtilsModule(InviwoApplication* app);
+    virtual ~ComputeUtilsModule() = default;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/computeutilsmodule.h
+++ b/misc/computeutils/include/inviwo/computeutils/computeutilsmodule.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/computeutilsmoduledefine.h
+++ b/misc/computeutils/include/inviwo/computeutils/computeutilsmoduledefine.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// clang-format off
+#ifdef INVIWO_ALL_DYN_LINK  //DYNAMIC
+	// If we are building DLL files we must declare dllexport/dllimport
+	#ifdef IVW_MODULE_COMPUTEUTILS_EXPORTS
+		#ifdef _WIN32
+			#define IVW_MODULE_COMPUTEUTILS_API __declspec(dllexport)
+		#else  //UNIX (GCC)
+			#define IVW_MODULE_COMPUTEUTILS_API __attribute__ ((visibility ("default")))
+		#endif
+	#else
+		#ifdef _WIN32
+			#define IVW_MODULE_COMPUTEUTILS_API __declspec(dllimport)
+		#else
+			#define IVW_MODULE_COMPUTEUTILS_API
+		#endif
+	#endif
+#else  //STATIC
+	#define IVW_MODULE_COMPUTEUTILS_API
+#endif
+// clang-format on

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
@@ -55,7 +55,7 @@ public:
 
     virtual void process() override;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
+    virtual const ProcessorInfo& getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 
 private:

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
@@ -1,0 +1,69 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/ports/volumeport.h>
+
+#include <inviwo/computeutils/algorithm/volumechannelsplitgl.h>
+
+namespace inviwo {
+
+/** \docpage{org.inviwo.VolumeChannelSplitGLProcessor, Volume Channel Split Processor}
+ * ![](org.inviwo.VolumeChannelSplitGLProcessor.png?classIdentifier=org.inviwo.VolumeChannelSplitGLProcessor)
+ *
+ * Splits a multi-channel volume into a set of single-channel volumes.
+ *
+ * ### Inports
+ *   * __Volume inport__ Input volume.
+ *
+ * ### Outports
+ *   * __Volume outport__ Set of single-channel volumes.
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeChannelSplitGLProcessor : public Processor {
+public:
+    VolumeChannelSplitGLProcessor();
+    virtual ~VolumeChannelSplitGLProcessor() = default;
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+    static const ProcessorInfo processorInfo_;
+
+private:
+    VolumeInport volumeInport_;
+
+    VolumeSequenceOutport volumeOutport_;
+    
+    VolumeChannelSplitGL volumeChannelSplitGl_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
@@ -62,7 +62,7 @@ private:
     VolumeInport volumeInport_;
 
     VolumeSequenceOutport volumeOutport_;
-    
+
     VolumeChannelSplitGL volumeChannelSplitGl_;
 };
 

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumechannelsplitglprocessor.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
@@ -1,0 +1,82 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/ports/volumeport.h>
+#include <inviwo/computeutils/algorithm/volumeminmaxgl.h>
+#include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/properties/minmaxproperty.h>
+
+namespace inviwo {
+
+/** \docpage{org.inviwo.VolumeMinMaxGLProcessor, Volume Min Max GLProcessor}
+ * ![](org.inviwo.VolumeMinMaxGLProcessor.png?classIdentifier=org.inviwo.VolumeMinMaxGLProcessor)
+ *
+ * This method calculates min and max values of a volume. If you need min/max per channel you should
+ * look at VolumeReductionGL. The disregarding status indicates whether or not the calculation of the
+ * min/max values should disregard a certain value range. This is for example handy for volumes where
+ * special regions are marked with voxel values of INT_MAX or the like. Example: Your data array
+ * consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the max value. In addition, you
+ * know that outliers are marked with a value of INT_MAX so you would like those values to not be
+ * considered.
+ *
+ * ### Inputs
+ *   * __Volume inport__ Input volume.
+ *
+ * ### Outports
+ *   * __Volume outport__ Reduced volume.
+ *
+ * ### Properties
+ *   * __Disregarding status__ Enable/disable value discarding
+ *   * __Disregarding range__ Value range to be discarded when computing minmax values.
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeMinMaxGLProcessor : public Processor {
+public:
+    VolumeMinMaxGLProcessor();
+    virtual ~VolumeMinMaxGLProcessor() = default;
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+    static const ProcessorInfo processorInfo_;
+
+private:
+    VolumeInport volumeInport_;
+    VolumeOutport volumeOutport_;
+
+    VolumeMinMaxGL volumeMinMaxGl_;
+
+    TemplateOptionProperty<DisregardingStatus> disregardingStatus_;
+    FloatMinMaxProperty disregardingRange_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
@@ -38,27 +38,6 @@
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.VolumeMinMaxGLProcessor, Volume Min Max GLProcessor}
- * ![](org.inviwo.VolumeMinMaxGLProcessor.png?classIdentifier=org.inviwo.VolumeMinMaxGLProcessor)
- *
- * This method calculates min and max values of a volume. If you need min/max per channel you should
- * look at VolumeReductionGL. The disregarding status indicates whether or not the calculation of
- * the min/max values should disregard a certain value range. This is for example handy for volumes
- * where special regions are marked with voxel values of INT_MAX or the like. Example: Your data
- * array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the max value. In addition,
- * you know that outliers are marked with a value of INT_MAX so you would like those values to not
- * be considered.
- *
- * ### Inputs
- *   * __Volume inport__ Input volume.
- *
- * ### Outports
- *   * __Volume outport__ Reduced volume.
- *
- * ### Properties
- *   * __Disregarding status__ Enable/disable value discarding
- *   * __Disregarding range__ Value range to be discarded when computing minmax values.
- */
 class IVW_MODULE_COMPUTEUTILS_API VolumeMinMaxGLProcessor : public Processor {
 public:
     VolumeMinMaxGLProcessor();
@@ -66,7 +45,7 @@ public:
 
     virtual void process() override;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
+    virtual const ProcessorInfo& getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 
 private:
@@ -75,7 +54,7 @@ private:
 
     VolumeMinMaxGL volumeMinMaxGl_;
 
-    TemplateOptionProperty<DisregardingStatus> disregardingStatus_;
+    OptionProperty<DisregardingStatus> disregardingStatus_;
     FloatMinMaxProperty disregardingRange_;
 };
 

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
@@ -42,12 +42,12 @@ namespace inviwo {
  * ![](org.inviwo.VolumeMinMaxGLProcessor.png?classIdentifier=org.inviwo.VolumeMinMaxGLProcessor)
  *
  * This method calculates min and max values of a volume. If you need min/max per channel you should
- * look at VolumeReductionGL. The disregarding status indicates whether or not the calculation of the
- * min/max values should disregard a certain value range. This is for example handy for volumes where
- * special regions are marked with voxel values of INT_MAX or the like. Example: Your data array
- * consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the max value. In addition, you
- * know that outliers are marked with a value of INT_MAX so you would like those values to not be
- * considered.
+ * look at VolumeReductionGL. The disregarding status indicates whether or not the calculation of
+ * the min/max values should disregard a certain value range. This is for example handy for volumes
+ * where special regions are marked with voxel values of INT_MAX or the like. Example: Your data
+ * array consists of {0, 1, 2, 3, INT_MAX} and you would like to compute the max value. In addition,
+ * you know that outliers are marked with a value of INT_MAX so you would like those values to not
+ * be considered.
  *
  * ### Inputs
  *   * __Volume inport__ Input volume.

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeminmaxglprocessor.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
@@ -70,7 +70,7 @@ public:
 
     virtual void process() override;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
+    virtual const ProcessorInfo& getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 
 private:

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
@@ -38,30 +38,11 @@
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.VolumeNormalizationGLProcessor, Volume Normalization Processor}
- * ![](org.inviwo.VolumeNormalizationGLProcessor.png?classIdentifier=org.inviwo.VolumeNormalizationGLProcessor)
- *
- * Normalizes the selected channels of the input volume to range [0,1].
- * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
- * volume in terms of vector norms!
- *
- * ### Inputs
- *   * __Volume inport__ Input Volume
- *
- * ### Outports
- *   * __Volume outport__ Normalized volume (if so selected)
- *
- * ### Properties
- *   * __Channels__ Check the boxes for those channels you wish to normalize to range [0,1]
- */
-
 /**
- * \class VolumeNormalizationGLProcessor
- *
- * Enables the usage of the %VolumeNormalization algorithm. For details about the algorithm,
- * please see VolumeNormalization.
+ * Enables the usage of the VolumeNormalizationGL algorithm.
  * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
  * volume in terms of vector norms!
+ * \see VolumeNormalizationGL
  */
 class IVW_MODULE_COMPUTEUTILS_API VolumeNormalizationGLProcessor : public Processor {
 public:

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
@@ -1,0 +1,89 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/ports/volumeport.h>
+#include <inviwo/computeutils/algorithm/volumenormalizationgl.h>
+
+namespace inviwo {
+
+/** \docpage{org.inviwo.VolumeNormalizationGLProcessor, Volume Normalization Processor}
+ * ![](org.inviwo.VolumeNormalizationGLProcessor.png?classIdentifier=org.inviwo.VolumeNormalizationGLProcessor)
+ *
+ * Normalizes the selected channels of the input volume to range [0,1].
+ * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
+ * volume in terms of vector norms!
+ *
+ * ### Inputs
+ *   * __Volume inport__ Input Volume
+ *
+ * ### Outports
+ *   * __Volume outport__ Normalized volume (if so selected)
+ *
+ * ### Properties
+ *   * __Channels__ Check the boxes for those channels you wish to normalize to range [0,1]
+ */
+
+/**
+ * \class VolumeNormalizationGLProcessor
+ *
+ * Enables the usage of the %VolumeNormalization algorithm. For details about the algorithm,
+ * please see VolumeNormalization.
+ * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
+ * volume in terms of vector norms!
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeNormalizationGLProcessor : public Processor {
+public:
+    VolumeNormalizationGLProcessor();
+    virtual ~VolumeNormalizationGLProcessor() = default;
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+    static const ProcessorInfo processorInfo_;
+
+private:
+    VolumeInport volumeInport_;
+    VolumeOutport volumeOutport_;
+
+    CompositeProperty channels_;
+    BoolProperty normalizeChannel0_;
+    BoolProperty normalizeChannel1_;
+    BoolProperty normalizeChannel2_;
+    BoolProperty normalizeChannel3_;
+
+    VolumeNormalizationGL volumeNormalization_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumenormalizationglprocessor.h
@@ -36,6 +36,8 @@
 #include <inviwo/core/ports/volumeport.h>
 #include <inviwo/computeutils/algorithm/volumenormalizationgl.h>
 
+#include <array>
+
 namespace inviwo {
 
 /**
@@ -59,10 +61,7 @@ private:
     VolumeOutport volumeOutport_;
 
     CompositeProperty channels_;
-    BoolProperty normalizeChannel0_;
-    BoolProperty normalizeChannel1_;
-    BoolProperty normalizeChannel2_;
-    BoolProperty normalizeChannel3_;
+    std::array<BoolProperty, 4> normalizeChannel_;
 
     VolumeNormalizationGL volumeNormalization_;
 };

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumereductionglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumereductionglprocessor.h
@@ -1,0 +1,74 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/computeutils/algorithm/volumereductiongl.h>
+#include <inviwo/core/ports/volumeport.h>
+#include <inviwo/core/properties/optionproperty.h>
+
+namespace inviwo {
+
+/** \docpage{org.inviwo.VolumeReductionGLProcessor, Volume Reduction Processor}
+ * ![](org.inviwo.VolumeReductionGLProcessor.png?classIdentifier=org.inviwo.VolumeReductionGLProcessor)
+ *
+ * GL implementation of add, min, and max reductions for 3D textures (volumes).
+ *
+ * ### Inputs
+ *   * __Volume inport__ Input volume.
+ *
+ * ### Outports
+ *   * __Volume outport__ Reduced volume.
+ *
+ * ### Properties
+ *   * __Reduction operator__ Operator for reduction.
+ *
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeReductionGLProcessor : public Processor {
+public:
+    VolumeReductionGLProcessor();
+    virtual ~VolumeReductionGLProcessor() = default;
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+    static const ProcessorInfo processorInfo_;
+
+private:
+    VolumeInport volumeInport_;
+    VolumeOutport volumeOutport_;
+
+    TemplateOptionProperty<ReductionOperator> reductionOperator_;
+
+    VolumeReductionGL gpuReduction_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumereductionglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumereductionglprocessor.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
@@ -72,7 +72,7 @@ public:
 
     virtual void process() override;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
+    virtual const ProcessorInfo& getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 
 private:

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
@@ -38,33 +38,6 @@
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.VolumeShrinkToNormalRangeGLProcessor, Volume Shrink To Normal Range
- * Processor}
- * ![](org.inviwo.VolumeShrinkToNormalRangeGLProcessor.png?classIdentifier=org.inviwo.VolumeShrinkToNormalRangeGLProcessor)
- *
- * Shrinks the selected channels of the input volume to range [0 + offset, 1 + offset] where offset
- * is the percentual deviaton of the minimum from 0. For example, range [-0.5, 1.0] will be shrunk
- * to [-0.33, 0.66].
- *
- * ### Inputs
- *   * __Volume inport__ Input Volume
- *
- * ### Outports
- *   * __Volume outport__ Shrunk volume (if so selected)
- *
- * ### Properties
- *   * __Channels__ Check the boxes for those channels you wish to shrink to range [0 + offset, 1 +
- * offset]
- */
-
-/**
- * \class VolumeShrinkToNormalRangeGLProcessor
- *
- * Enables the usage of the %VolumeNormalization algorithm. For details about the algorithm,
- * please see VolumeNormalization.
- * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
- * volume in terms of vector norms!
- */
 class IVW_MODULE_COMPUTEUTILS_API VolumeShrinkToNormalRangeGLProcessor : public Processor {
 public:
     VolumeShrinkToNormalRangeGLProcessor();

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
@@ -1,0 +1,91 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/computeutils/computeutilsmoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/ports/volumeport.h>
+#include <inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h>
+
+namespace inviwo {
+
+/** \docpage{org.inviwo.VolumeShrinkToNormalRangeGLProcessor, Volume Shrink To Normal Range
+ * Processor}
+ * ![](org.inviwo.VolumeShrinkToNormalRangeGLProcessor.png?classIdentifier=org.inviwo.VolumeShrinkToNormalRangeGLProcessor)
+ *
+ * Shrinks the selected channels of the input volume to range [0 + offset, 1 + offset] where offset
+ * is the percentual deviaton of the minimum from 0. For example, range [-0.5, 1.0] will be shrunk
+ * to [-0.33, 0.66].
+ *
+ * ### Inputs
+ *   * __Volume inport__ Input Volume
+ *
+ * ### Outports
+ *   * __Volume outport__ Shrunk volume (if so selected)
+ *
+ * ### Properties
+ *   * __Channels__ Check the boxes for those channels you wish to shrink to range [0 + offset, 1 +
+ * offset]
+ */
+
+/**
+ * \class VolumeShrinkToNormalRangeGLProcessor
+ *
+ * Enables the usage of the %VolumeNormalization algorithm. For details about the algorithm,
+ * please see VolumeNormalization.
+ * Note that this algorithm normalizes channels independently, it does not normalize a multi-channel
+ * volume in terms of vector norms!
+ */
+class IVW_MODULE_COMPUTEUTILS_API VolumeShrinkToNormalRangeGLProcessor : public Processor {
+public:
+    VolumeShrinkToNormalRangeGLProcessor();
+    virtual ~VolumeShrinkToNormalRangeGLProcessor() = default;
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+    static const ProcessorInfo processorInfo_;
+
+private:
+    VolumeInport volumeInport_;
+    VolumeOutport volumeOutport_;
+
+    CompositeProperty channels_;
+    BoolProperty shrinkChannel0_;
+    BoolProperty shrinkChannel1_;
+    BoolProperty shrinkChannel2_;
+    BoolProperty shrinkChannel3_;
+
+    VolumeShrinkToNormalRangeGL volumeShrinkToNormalRangeGl_;
+};
+
+}  // namespace inviwo

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
+++ b/misc/computeutils/include/inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h
@@ -36,6 +36,8 @@
 #include <inviwo/core/ports/volumeport.h>
 #include <inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h>
 
+#include <array>
+
 namespace inviwo {
 
 class IVW_MODULE_COMPUTEUTILS_API VolumeShrinkToNormalRangeGLProcessor : public Processor {
@@ -53,10 +55,7 @@ private:
     VolumeOutport volumeOutport_;
 
     CompositeProperty channels_;
-    BoolProperty shrinkChannel0_;
-    BoolProperty shrinkChannel1_;
-    BoolProperty shrinkChannel2_;
-    BoolProperty shrinkChannel3_;
+    std::array<BoolProperty, 4> shrinkChannel_;
 
     VolumeShrinkToNormalRangeGL volumeShrinkToNormalRangeGl_;
 };

--- a/misc/computeutils/readme.md
+++ b/misc/computeutils/readme.md
@@ -1,0 +1,3 @@
+# ComputeUtils Module
+
+Description of the ComputeUtils module

--- a/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
+++ b/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
@@ -1,0 +1,115 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/algorithm/volumechannelsplitgl.h>
+
+#include <modules/opengl/volume/volumegl.h>
+#include <modules/opengl/shader/shaderutils.h>
+#include <modules/opengl/volume/volumeutils.h>
+
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/datastructures/volume/volumeram.h>
+
+namespace inviwo {
+
+VolumeChannelSplitGL::VolumeChannelSplitGL()
+    : shader_({{ShaderType::Compute, utilgl::findShaderResource("volumesplit.comp")}},
+              Shader::Build::No) {}
+
+std::vector<std::shared_ptr<Volume>> VolumeChannelSplitGL::split(
+    std::shared_ptr<const Volume> volume) {
+    std::vector<std::shared_ptr<Volume>> outVolumes;
+
+    const auto oldDataFormat = volume->getDataFormat();
+
+    const auto numericType = oldDataFormat->getNumericType();
+    const auto numberOfComponents = 1;
+    const auto precision = oldDataFormat->getPrecision();
+
+    auto dataFormat = DataFormatBase::get(numericType, numberOfComponents, precision);
+
+    const auto dimensions = volume->getDimensions();
+
+    for (auto i{0};i<4;++i) {
+        shader_.getShaderObject(ShaderType::Compute)
+            ->removeShaderDefine(StrBuffer("CHANNEL {}", i));
+    }
+
+    for (size_t i{0}; i < volume->getDataFormat()->getComponents(); ++i) {
+        auto outVolume = std::make_shared<Volume>(
+            volume->getDimensions(), dataFormat, swizzlemasks::rgba, volume->getInterpolation(),
+            Wrapping3D{Wrapping::Clamp, Wrapping::Clamp, Wrapping::Clamp});
+
+        outVolume->setModelMatrix(volume->getModelMatrix());
+        outVolume->setWorldMatrix(volume->getWorldMatrix());
+        outVolume->copyMetaDataFrom(*volume);
+
+        outVolumes.push_back(outVolume);
+
+        shader_.getShaderObject(ShaderType::Compute)
+            ->removeShaderDefine(StrBuffer("CHANNEL {}", i - 1));
+        shader_.getShaderObject(ShaderType::Compute)->addShaderDefine(StrBuffer("CHANNEL {}", i));
+        shader_.build();
+
+        shader_.activate();
+
+        TextureUnitContainer cont;
+        utilgl::bindAndSetUniforms(shader_, cont, *volume, "inputTexture");
+
+        shader_.setUniform("outputTexture", 0);
+
+        auto outVolumeGL = outVolume->getEditableRepresentation<VolumeGL>();
+
+        glActiveTexture(GL_TEXTURE0);
+
+        const auto texture = outVolumeGL->getTexture();
+        const auto texHandle = texture->getID();
+        glBindImageTexture(0, texHandle, 0, GL_FALSE, 0, GL_WRITE_ONLY,
+                           texture->getInternalFormat());
+
+        outVolumeGL->getTexture()->bind();
+
+        glDispatchCompute(static_cast<GLuint>(dimensions.x), static_cast<GLuint>(dimensions.y),
+                          static_cast<GLuint>(dimensions.z));
+
+        glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+        shader_.deactivate();
+    }
+
+    for (auto outVolume : outVolumes) {
+        outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange =
+            dvec2{volumeReductionGl_.reduce_v(outVolume, ReductionOperator::Min),
+                  volumeReductionGl_.reduce_v(outVolume, ReductionOperator::Max)};
+    }
+
+    return outVolumes;
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
+++ b/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
@@ -56,7 +56,7 @@ std::vector<std::shared_ptr<Volume>> VolumeChannelSplitGL::split(
 
     const auto dimensions = volume->getDimensions();
 
-    for (auto i{0};i<4;++i) {
+    for (auto i{0}; i < 4; ++i) {
         shader_.getShaderObject(ShaderType::Compute)
             ->removeShaderDefine(StrBuffer("CHANNEL {}", i));
     }

--- a/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
+++ b/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
@@ -32,6 +32,8 @@
 #include <modules/opengl/volume/volumegl.h>
 #include <modules/opengl/shader/shaderutils.h>
 #include <modules/opengl/volume/volumeutils.h>
+#include <modules/opengl/texture/textureunit.h>
+#include <modules/opengl/texture/texture3d.h>
 
 #include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/datastructures/volume/volumeram.h>
@@ -42,7 +44,7 @@ VolumeChannelSplitGL::VolumeChannelSplitGL()
     : shader_({{ShaderType::Compute, utilgl::findShaderResource("volumesplit.comp")}},
               Shader::Build::No) {}
 
-std::vector<std::shared_ptr<Volume>> VolumeChannelSplitGL::split(
+VolumeSequence VolumeChannelSplitGL::split(
     std::shared_ptr<const Volume> volume) {
     std::vector<std::shared_ptr<Volume>> outVolumes;
 
@@ -104,12 +106,12 @@ std::vector<std::shared_ptr<Volume>> VolumeChannelSplitGL::split(
     }
 
     for (auto outVolume : outVolumes) {
-        outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange =
+        outVolume->dataMap.dataRange = outVolume->dataMap.valueRange =
             dvec2{volumeReductionGl_.reduce_v(outVolume, ReductionOperator::Min),
                   volumeReductionGl_.reduce_v(outVolume, ReductionOperator::Max)};
     }
 
-    return outVolumes;
+    return VolumeSequence{outVolumes};
 }
 
 }  // namespace inviwo

--- a/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
+++ b/misc/computeutils/src/algorithm/volumechannelsplitgl.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/algorithm/volumeminmaxgl.cpp
+++ b/misc/computeutils/src/algorithm/volumeminmaxgl.cpp
@@ -1,0 +1,43 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/algorithm/volumeminmaxgl.h>
+
+namespace inviwo {
+dvec2 VolumeMinMaxGL::minmax(std::shared_ptr<const Volume> volume, DisregardingStatus disregardingStatus,
+                             const vec2& range) {
+    const auto min =
+        volumeReductionGL_.reduce_v(volume, ReductionOperator::Min, disregardingStatus, range);
+    const auto max =
+        volumeReductionGL_.reduce_v(volume, ReductionOperator::Max, disregardingStatus, range);
+
+    return dvec2{min, max};
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/algorithm/volumeminmaxgl.cpp
+++ b/misc/computeutils/src/algorithm/volumeminmaxgl.cpp
@@ -30,8 +30,8 @@
 #include <inviwo/computeutils/algorithm/volumeminmaxgl.h>
 
 namespace inviwo {
-dvec2 VolumeMinMaxGL::minmax(std::shared_ptr<const Volume> volume, DisregardingStatus disregardingStatus,
-                             const vec2& range) {
+dvec2 VolumeMinMaxGL::minmax(std::shared_ptr<const Volume> volume,
+                             DisregardingStatus disregardingStatus, const vec2& range) {
     const auto min =
         volumeReductionGL_.reduce_v(volume, ReductionOperator::Min, disregardingStatus, range);
     const auto max =

--- a/misc/computeutils/src/algorithm/volumeminmaxgl.cpp
+++ b/misc/computeutils/src/algorithm/volumeminmaxgl.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
+++ b/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
@@ -1,0 +1,139 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/algorithm/volumenormalizationgl.h>
+
+#include <modules/opengl/volume/volumegl.h>
+#include <modules/opengl/shader/shaderutils.h>
+#include <modules/opengl/volume/volumeutils.h>
+
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/datastructures/volume/volumeram.h>
+#include <inviwo/core/datastructures/volume/volumeramprecision.h>
+
+namespace inviwo {
+
+VolumeNormalizationGL::VolumeNormalizationGL()
+    : shader_({{ShaderType::Compute, utilgl::findShaderResource("volumenormalization.comp")}},
+              Shader::Build::No)
+    , needsCompilation_(false) {
+    shader_.getShaderObject(ShaderType::Compute)->addShaderDefine("NORMALIZE_CHANNEL_0");
+    shader_.build();
+}
+
+void VolumeNormalizationGL::setNormalizeChannel(const size_t channel, const bool normalize) {
+    needsCompilation_ = true;
+
+    if (normalize) {
+        shader_.getShaderObject(ShaderType::Compute)
+            ->addShaderDefine(StrBuffer{"NORMALIZE_CHANNEL_{}", channel});
+    } else {
+        shader_.getShaderObject(ShaderType::Compute)
+            ->removeShaderDefine(StrBuffer{"NORMALIZE_CHANNEL_{}", channel});
+    }
+}
+
+void VolumeNormalizationGL::setNormalizeChannels(bvec4 normalize) {
+    setNormalizeChannel(0, normalize[0]);
+    setNormalizeChannel(1, normalize[1]);
+    setNormalizeChannel(2, normalize[2]);
+    setNormalizeChannel(3, normalize[3]);
+}
+
+void VolumeNormalizationGL::reset() { setNormalizeChannels({true, false, false, false}); }
+
+std::shared_ptr<Volume> VolumeNormalizationGL::normalize(const Volume& volume) {
+    std::shared_ptr<Volume> outVolume;
+
+    // Don't dispatch if we don't have to
+    if (volume.getDataFormat()->getNumericType() == NumericType::Float) {
+        outVolume = std::make_shared<Volume>(volume.getDimensions(), volume.getDataFormat(),
+                                             volume.getSwizzleMask(), volume.getInterpolation(),
+                                             volume.getWrapping());
+    } else {
+        outVolume = volume.getRepresentation<VolumeRAM>()
+                        ->dispatch<std::shared_ptr<Volume>, dispatching::filter::Integers>(
+                            [](auto vrprecision) {
+                                using ValueType = util::PrecisionValueType<decltype(vrprecision)>;
+
+                                using P = typename util::same_extent<ValueType, float>::type;
+
+                                return std::make_shared<Volume>(
+                                    vrprecision->getDimensions(), DataFormat<P>::get(),
+                                    vrprecision->getSwizzleMask(), vrprecision->getInterpolation(),
+                                    vrprecision->getWrapping());
+                            });
+    }
+
+    outVolume->setModelMatrix(volume.getModelMatrix());
+    outVolume->setWorldMatrix(volume.getWorldMatrix());
+    outVolume->copyMetaDataFrom(volume);
+
+    if (needsCompilation_) {
+        needsCompilation_ = false;
+        shader_.build();
+    }
+
+    const auto dimensions = volume.getDimensions();
+
+    shader_.activate();
+
+    TextureUnitContainer cont;
+    utilgl::bindAndSetUniforms(shader_, cont, volume, "inputTexture");
+    shader_.setUniform("outputTexture", 0);
+
+    auto outVolumeGL = outVolume->getEditableRepresentation<VolumeGL>();
+    outVolumeGL->setWrapping({Wrapping::Clamp, Wrapping::Clamp, Wrapping::Clamp});
+
+    glActiveTexture(GL_TEXTURE0);
+
+    const auto texture = outVolumeGL->getTexture();
+    const auto texHandle = texture->getID();
+    glBindImageTexture(0, texHandle, 0, GL_FALSE, 0, GL_WRITE_ONLY, texture->getInternalFormat());
+
+    outVolumeGL->setSwizzleMask(swizzlemasks::rgba);
+
+    outVolumeGL->getTexture()->bind();
+
+    /*
+     * Run normalization.
+     */
+    glDispatchCompute(static_cast<GLuint>(dimensions.x), static_cast<GLuint>(dimensions.y),
+                      static_cast<GLuint>(dimensions.z));
+
+    glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+    shader_.deactivate();
+
+    outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange = dvec2{0, 1};
+
+    return outVolume;
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
+++ b/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
@@ -46,7 +46,6 @@ VolumeNormalizationGL::VolumeNormalizationGL()
               Shader::Build::No)
     , needsCompilation_(false) {
     shader_.getShaderObject(ShaderType::Compute)->addShaderDefine("NORMALIZE_CHANNEL_0");
-    shader_.build();
 }
 
 void VolumeNormalizationGL::setNormalizeChannel(const size_t channel, const bool normalize) {
@@ -97,7 +96,7 @@ std::shared_ptr<Volume> VolumeNormalizationGL::normalize(const Volume& volume) {
     outVolume->setWorldMatrix(volume.getWorldMatrix());
     outVolume->copyMetaDataFrom(volume);
 
-    if (needsCompilation_) {
+    if (needsCompilation_ || !shader_.isReady()) {
         needsCompilation_ = false;
         shader_.build();
     }

--- a/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
+++ b/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
@@ -32,6 +32,8 @@
 #include <modules/opengl/volume/volumegl.h>
 #include <modules/opengl/shader/shaderutils.h>
 #include <modules/opengl/volume/volumeutils.h>
+#include <modules/opengl/texture/textureunit.h>
+#include <modules/opengl/texture/texture3d.h>
 
 #include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/datastructures/volume/volumeram.h>
@@ -131,7 +133,7 @@ std::shared_ptr<Volume> VolumeNormalizationGL::normalize(const Volume& volume) {
 
     shader_.deactivate();
 
-    outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange = dvec2{0, 1};
+    outVolume->dataMap.dataRange = outVolume->dataMap.valueRange = dvec2{0, 1};
 
     return outVolume;
 }

--- a/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
+++ b/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
+++ b/misc/computeutils/src/algorithm/volumenormalizationgl.cpp
@@ -39,6 +39,8 @@
 #include <inviwo/core/datastructures/volume/volumeram.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
 
+#include <fmt/base.h>
+
 namespace inviwo {
 
 VolumeNormalizationGL::VolumeNormalizationGL()
@@ -51,13 +53,8 @@ VolumeNormalizationGL::VolumeNormalizationGL()
 void VolumeNormalizationGL::setNormalizeChannel(const size_t channel, const bool normalize) {
     needsCompilation_ = true;
 
-    if (normalize) {
-        shader_.getShaderObject(ShaderType::Compute)
-            ->addShaderDefine(StrBuffer{"NORMALIZE_CHANNEL_{}", channel});
-    } else {
-        shader_.getShaderObject(ShaderType::Compute)
-            ->removeShaderDefine(StrBuffer{"NORMALIZE_CHANNEL_{}", channel});
-    }
+    shader_.getComputeShaderObject()->setShaderDefine(fmt::format("NORMALIZE_CHANNEL_{}", channel),
+                                                      normalize);
 }
 
 void VolumeNormalizationGL::setNormalizeChannels(bvec4 normalize) {

--- a/misc/computeutils/src/algorithm/volumereductiongl.cpp
+++ b/misc/computeutils/src/algorithm/volumereductiongl.cpp
@@ -28,14 +28,20 @@
  *********************************************************************************/
 
 #include <inviwo/computeutils/algorithm/volumereductiongl.h>
+#include <inviwo/core/util/stringconversion.h>
 
 #include <modules/opengl/volume/volumegl.h>
 #include <modules/opengl/shader/shaderutils.h>
 #include <modules/opengl/volume/volumeutils.h>
+#include <modules/opengl/texture/textureunit.h>
+#include <modules/opengl/texture/textureutils.h>
+#include <modules/opengl/texture/texture3d.h>
 
 #include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/datastructures/volume/volumeram.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
+
+#include <fmt/base.h>
 
 namespace inviwo {
 

--- a/misc/computeutils/src/algorithm/volumereductiongl.cpp
+++ b/misc/computeutils/src/algorithm/volumereductiongl.cpp
@@ -1,0 +1,190 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/algorithm/volumereductiongl.h>
+
+#include <modules/opengl/volume/volumegl.h>
+#include <modules/opengl/shader/shaderutils.h>
+#include <modules/opengl/volume/volumeutils.h>
+
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/datastructures/volume/volumeram.h>
+#include <inviwo/core/datastructures/volume/volumeramprecision.h>
+
+namespace inviwo {
+
+VolumeReductionGL::VolumeReductionGL()
+    : shader_({{ShaderType::Compute, utilgl::findShaderResource("volumereduction.comp")}},
+              Shader::Build::No)
+    , activeReductionOperator_(ReductionOperator::None)
+    , activeDisregardingStatus_(DisregardingStatus::Unset) {}
+
+std::shared_ptr<Volume> VolumeReductionGL::reduce(std::shared_ptr<const Volume> volume,
+                                                  const ReductionOperator op,
+                                                  DisregardingStatus disregardingStatus,
+                                                  const vec2& range) {
+    setReductionOperator(op);
+    setDisregarding(disregardingStatus);
+    setSamplerType(volume);
+
+    shader_.build();
+
+    shader_.activate();
+
+    const auto dimensions = volume->getDimensions();
+
+    auto input = std::shared_ptr<Volume>(volume->clone());
+    auto dataFormat = volume->getDataFormat();
+    std::shared_ptr<Volume> output;
+
+    auto m = static_cast<GLuint>(dimensions.x) / GLuint{2};
+    auto n = static_cast<GLuint>(dimensions.y) / GLuint{2};
+    auto o = static_cast<GLuint>(dimensions.z) / GLuint{2};
+
+    while (true) {
+        /*
+         * Bind textures and set uniforms.
+         */
+        TextureUnitContainer cont;
+        utilgl::bindAndSetUniforms(shader_, cont, *input, "inputTexture");
+        shader_.setUniform("outputTexture", 0);
+
+        /*
+         * Set value disregarding parameters
+         */
+        shader_.setUniform("disregardingRange", range);
+
+        /*
+         * Update output texture.
+         */
+        output = std::make_shared<Volume>(size3_t{m, n, o}, dataFormat);
+        auto outputGL = output->getEditableRepresentation<VolumeGL>();
+        outputGL->setWrapping({Wrapping::Clamp, Wrapping::Clamp, Wrapping::Clamp});
+
+        glActiveTexture(GL_TEXTURE0);
+
+        auto texture = outputGL->getTexture();
+        auto texHandle = texture->getID();
+        glBindImageTexture(0, texHandle, 0, GL_FALSE, 0, GL_WRITE_ONLY,
+                           texture->getInternalFormat());
+
+        outputGL->setSwizzleMask(swizzlemasks::rgba);
+
+        outputGL->getTexture()->bind();
+
+        /*
+         * Run reduction.
+         */
+        gpuDispatch(m, n, o);
+
+        /*
+         * When we have reached an output texture size of 1, the reduction is complete.
+         */
+        if (m == 1 && n == 1 && o == 1) break;
+
+        /*
+         * Swap textures.
+         */
+        std::swap(input, output);
+
+        /*
+         * Update output texture size
+         */
+        m = std::max(m / 2, GLuint{1});
+        n = std::max(n / 2, GLuint{1});
+        o = std::max(o / 2, GLuint{1});
+    }
+
+    shader_.deactivate();
+
+    return output;
+}
+
+double VolumeReductionGL::reduce_v(std::shared_ptr<const Volume> volume, const ReductionOperator op,
+                                   DisregardingStatus disregardingStatus, const vec2& range) {
+    auto res = reduce(volume, op, disregardingStatus, range);
+
+    return res->getRepresentation<VolumeRAM>()->getAsDouble(size3_t{0, 0, 0});
+}
+
+void VolumeReductionGL::setReductionOperator(ReductionOperator op) {
+    if (op == activeReductionOperator_) return;
+
+    auto computeShader = shader_.getComputeShaderObject();
+    computeShader->removeShaderDefine(StrBuffer{"OPERATOR {}", activeReductionOperator_});
+
+    activeReductionOperator_ = op;
+
+    computeShader->addShaderDefine(StrBuffer{"OPERATOR {}", activeReductionOperator_});
+}
+
+void VolumeReductionGL::setDisregarding(DisregardingStatus disregardingStatus) {
+    if (disregardingStatus == activeDisregardingStatus_) return;
+
+    auto computeShader = shader_.getComputeShaderObject();
+    computeShader->removeShaderDefine(StrBuffer{"DISREGARD {}", activeDisregardingStatus_});
+
+    activeDisregardingStatus_ = disregardingStatus;
+
+    computeShader->addShaderDefine(StrBuffer{"DISREGARD {}", activeDisregardingStatus_});
+}
+
+void VolumeReductionGL::setSamplerType(std::shared_ptr<const Volume> volume) {
+    auto computeShader = shader_.getComputeShaderObject();
+
+    /*
+     * Reset just to be sure.
+     */
+    computeShader->removeShaderDefine("REDUCTION_SAMPLER_TYPE_FLOAT");
+    computeShader->removeShaderDefine("REDUCTION_SAMPLER_TYPE_INTEGER");
+    computeShader->removeShaderDefine("REDUCTION_SAMPLER_TYPE_UNSIGNED");
+
+    volume->getRepresentation<VolumeRAM>()->dispatch<void, dispatching::filter::All>(
+        [&computeShader](auto vrprecision) {
+            using VectorType = util::PrecisionValueType<decltype(vrprecision)>;
+            using ValueType = util::value_type_t<VectorType>;
+
+            if constexpr (std::is_floating_point_v<ValueType>) {
+                computeShader->addShaderDefine("REDUCTION_SAMPLER_TYPE_FLOAT");
+            }
+            if constexpr (std::is_integral_v<ValueType>) {
+                computeShader->addShaderDefine("REDUCTION_SAMPLER_TYPE_SIGNED");
+            }
+            if constexpr (std::is_unsigned_v<ValueType>) {
+                computeShader->addShaderDefine("REDUCTION_SAMPLER_TYPE_UNSIGNED");
+            }
+        });
+}
+
+void VolumeReductionGL::gpuDispatch(const GLuint x, const GLuint y, const GLuint z) {
+    glDispatchCompute(x, y, z);
+
+    glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+}
+}  // namespace inviwo

--- a/misc/computeutils/src/algorithm/volumereductiongl.cpp
+++ b/misc/computeutils/src/algorithm/volumereductiongl.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
+++ b/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
@@ -1,0 +1,145 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/algorithm/volumeshrinktonormalrangegl.h>
+
+#include <modules/opengl/volume/volumegl.h>
+#include <modules/opengl/shader/shaderutils.h>
+#include <modules/opengl/volume/volumeutils.h>
+
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/datastructures/volume/volumeram.h>
+#include <inviwo/core/datastructures/volume/volumeramprecision.h>
+
+namespace inviwo {
+
+VolumeShrinkToNormalRangeGL::VolumeShrinkToNormalRangeGL()
+    : shader_({{ShaderType::Compute, utilgl::findShaderResource("volumeshrinktonormalrange.comp")}},
+              Shader::Build::No)
+    , needsCompilation_(false) {
+    shader_.getShaderObject(ShaderType::Compute)->addShaderDefine("SHRINK_CHANNEL_0");
+    shader_.build();
+}
+
+void VolumeShrinkToNormalRangeGL::setShrinkChannel(const size_t channel, const bool shrink) {
+    needsCompilation_ = true;
+
+    if (shrink) {
+        shader_.getShaderObject(ShaderType::Compute)
+            ->addShaderDefine(StrBuffer{"SHRINK_CHANNEL_{}", channel});
+    } else {
+        shader_.getShaderObject(ShaderType::Compute)
+            ->removeShaderDefine(StrBuffer{"SHRINK_CHANNEL_{}", channel});
+    }
+}
+
+void VolumeShrinkToNormalRangeGL::setShrinkChannels(bvec4 normalize) {
+    setShrinkChannel(0, normalize[0]);
+    setShrinkChannel(1, normalize[1]);
+    setShrinkChannel(2, normalize[2]);
+    setShrinkChannel(3, normalize[3]);
+}
+
+void VolumeShrinkToNormalRangeGL::reset() { setShrinkChannels({true, false, false, false}); }
+
+std::shared_ptr<Volume> VolumeShrinkToNormalRangeGL::shrink(const Volume& volume) {
+    std::shared_ptr<Volume> outVolume;
+
+    const auto offset = (volume.dataMap_.dataRange.x < 0.0 && volume.dataMap_.dataRange.y > 0.0)
+                            ? volume.dataMap_.dataRange.x /
+                                  (volume.dataMap_.dataRange.y - volume.dataMap_.dataRange.x)
+                            : 0.0;
+
+    // Don't dispatch if we don't have to
+    if (volume.getDataFormat()->getNumericType() == NumericType::Float) {
+        outVolume = std::make_shared<Volume>(volume.getDimensions(), volume.getDataFormat(),
+                                             volume.getSwizzleMask(), volume.getInterpolation(),
+                                             volume.getWrapping());
+    } else {
+        outVolume = volume.getRepresentation<VolumeRAM>()
+                        ->dispatch<std::shared_ptr<Volume>, dispatching::filter::Integers>(
+                            [](auto vrprecision) {
+                                using ValueType = util::PrecisionValueType<decltype(vrprecision)>;
+
+                                using P = typename util::same_extent<ValueType, float>::type;
+
+                                return std::make_shared<Volume>(
+                                    vrprecision->getDimensions(), DataFormat<P>::get(),
+                                    vrprecision->getSwizzleMask(), vrprecision->getInterpolation(),
+                                    vrprecision->getWrapping());
+                            });
+    }
+
+    outVolume->setModelMatrix(volume.getModelMatrix());
+    outVolume->setWorldMatrix(volume.getWorldMatrix());
+    outVolume->copyMetaDataFrom(volume);
+
+    if (needsCompilation_) {
+        needsCompilation_ = false;
+        shader_.build();
+    }
+
+    const auto dimensions = volume.getDimensions();
+
+    shader_.activate();
+
+    TextureUnitContainer cont;
+    utilgl::bindAndSetUniforms(shader_, cont, volume, "inputTexture");
+    shader_.setUniform("outputTexture", 0);
+    shader_.setUniform("offset", static_cast<float>(offset));
+
+    auto outVolumeGL = outVolume->getEditableRepresentation<VolumeGL>();
+    outVolumeGL->setWrapping({Wrapping::Clamp, Wrapping::Clamp, Wrapping::Clamp});
+
+    glActiveTexture(GL_TEXTURE0);
+
+    const auto texture = outVolumeGL->getTexture();
+    const auto texHandle = texture->getID();
+    glBindImageTexture(0, texHandle, 0, GL_FALSE, 0, GL_WRITE_ONLY, texture->getInternalFormat());
+
+    outVolumeGL->setSwizzleMask(swizzlemasks::rgba);
+
+    outVolumeGL->getTexture()->bind();
+
+    /*
+     * Run normalization.
+     */
+    glDispatchCompute(static_cast<GLuint>(dimensions.x), static_cast<GLuint>(dimensions.y),
+                      static_cast<GLuint>(dimensions.z));
+
+    glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+    shader_.deactivate();
+
+    outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange = dvec2{0 + offset, 1 + offset};
+
+    return outVolume;
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
+++ b/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
@@ -32,6 +32,8 @@
 #include <modules/opengl/volume/volumegl.h>
 #include <modules/opengl/shader/shaderutils.h>
 #include <modules/opengl/volume/volumeutils.h>
+#include <modules/opengl/texture/textureunit.h>
+#include <modules/opengl/texture/texture3d.h>
 
 #include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/datastructures/volume/volumeram.h>
@@ -71,9 +73,9 @@ void VolumeShrinkToNormalRangeGL::reset() { setShrinkChannels({true, false, fals
 std::shared_ptr<Volume> VolumeShrinkToNormalRangeGL::shrink(const Volume& volume) {
     std::shared_ptr<Volume> outVolume;
 
-    const auto offset = (volume.dataMap_.dataRange.x < 0.0 && volume.dataMap_.dataRange.y > 0.0)
-                            ? volume.dataMap_.dataRange.x /
-                                  (volume.dataMap_.dataRange.y - volume.dataMap_.dataRange.x)
+    const auto offset = (volume.dataMap.dataRange.x < 0.0 && volume.dataMap.dataRange.y > 0.0)
+                            ? volume.dataMap.dataRange.x /
+                                  (volume.dataMap.dataRange.y - volume.dataMap.dataRange.x)
                             : 0.0;
 
     // Don't dispatch if we don't have to
@@ -137,7 +139,7 @@ std::shared_ptr<Volume> VolumeShrinkToNormalRangeGL::shrink(const Volume& volume
 
     shader_.deactivate();
 
-    outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange = dvec2{0 + offset, 1 + offset};
+    outVolume->dataMap.dataRange = outVolume->dataMap.valueRange = dvec2{0 + offset, 1 + offset};
 
     return outVolume;
 }

--- a/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
+++ b/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
@@ -46,7 +46,6 @@ VolumeShrinkToNormalRangeGL::VolumeShrinkToNormalRangeGL()
               Shader::Build::No)
     , needsCompilation_(false) {
     shader_.getShaderObject(ShaderType::Compute)->addShaderDefine("SHRINK_CHANNEL_0");
-    shader_.build();
 }
 
 void VolumeShrinkToNormalRangeGL::setShrinkChannel(const size_t channel, const bool shrink) {
@@ -73,10 +72,10 @@ void VolumeShrinkToNormalRangeGL::reset() { setShrinkChannels({true, false, fals
 std::shared_ptr<Volume> VolumeShrinkToNormalRangeGL::shrink(const Volume& volume) {
     std::shared_ptr<Volume> outVolume;
 
-    const auto offset = (volume.dataMap.dataRange.x < 0.0 && volume.dataMap.dataRange.y > 0.0)
-                            ? volume.dataMap.dataRange.x /
-                                  (volume.dataMap.dataRange.y - volume.dataMap.dataRange.x)
-                            : 0.0;
+    const auto offset =
+        (volume.dataMap.dataRange.x < 0.0 && volume.dataMap.dataRange.y > 0.0)
+            ? volume.dataMap.dataRange.x / (volume.dataMap.dataRange.y - volume.dataMap.dataRange.x)
+            : 0.0;
 
     // Don't dispatch if we don't have to
     if (volume.getDataFormat()->getNumericType() == NumericType::Float) {
@@ -102,7 +101,7 @@ std::shared_ptr<Volume> VolumeShrinkToNormalRangeGL::shrink(const Volume& volume
     outVolume->setWorldMatrix(volume.getWorldMatrix());
     outVolume->copyMetaDataFrom(volume);
 
-    if (needsCompilation_) {
+    if (needsCompilation_ || !shader_.isReady()) {
         needsCompilation_ = false;
         shader_.build();
     }

--- a/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
+++ b/misc/computeutils/src/algorithm/volumeshrinktonormalrangegl.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2016-2021 Inviwo Foundation
+ * Copyright (c) 2016-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/computeutilsmodule.cpp
+++ b/misc/computeutils/src/computeutilsmodule.cpp
@@ -1,0 +1,50 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/computeutilsmodule.h>
+#include <inviwo/computeutils/processors/volumechannelsplitglprocessor.h>
+#include <inviwo/computeutils/processors/volumeminmaxglprocessor.h>
+#include <inviwo/computeutils/processors/volumereductionglprocessor.h>
+#include <modules/opengl/shader/shadermanager.h>
+#include <inviwo/computeutils/processors/volumenormalizationglprocessor.h>
+#include <inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h>
+
+namespace inviwo {
+
+ComputeUtilsModule::ComputeUtilsModule(InviwoApplication* app) : InviwoModule(app, "ComputeUtils") {
+    ShaderManager::getPtr()->addShaderSearchPath(getPath(ModulePath::GLSL));
+    
+    registerProcessor<VolumeChannelSplitGLProcessor>();
+    registerProcessor<VolumeMinMaxGLProcessor>();
+    registerProcessor<VolumeNormalizationGLProcessor>();
+    registerProcessor<VolumeReductionGLProcessor>();
+    registerProcessor<VolumeShrinkToNormalRangeGLProcessor>();
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/computeutilsmodule.cpp
+++ b/misc/computeutils/src/computeutilsmodule.cpp
@@ -39,7 +39,7 @@ namespace inviwo {
 
 ComputeUtilsModule::ComputeUtilsModule(InviwoApplication* app) : InviwoModule(app, "ComputeUtils") {
     ShaderManager::getPtr()->addShaderSearchPath(getPath(ModulePath::GLSL));
-    
+
     registerProcessor<VolumeChannelSplitGLProcessor>();
     registerProcessor<VolumeMinMaxGLProcessor>();
     registerProcessor<VolumeNormalizationGLProcessor>();

--- a/misc/computeutils/src/computeutilsmodule.cpp
+++ b/misc/computeutils/src/computeutilsmodule.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
@@ -39,7 +39,7 @@ const ProcessorInfo VolumeChannelSplitGLProcessor::processorInfo_{
     CodeState::Experimental,                     // Code state
     Tags::GL,                                    // Tags
 };
-const ProcessorInfo VolumeChannelSplitGLProcessor::getProcessorInfo() const {
+const ProcessorInfo& VolumeChannelSplitGLProcessor::getProcessorInfo() const {
     return processorInfo_;
 }
 

--- a/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
@@ -1,0 +1,62 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/processors/volumechannelsplitglprocessor.h>
+
+namespace inviwo {
+
+// The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
+const ProcessorInfo VolumeChannelSplitGLProcessor::processorInfo_{
+    "org.inviwo.VolumeChannelSplitGLProcessor",  // Class identifier
+    "Volume Channel Split Processor",            // Display name
+    "Volume Operation",                             // Category
+    CodeState::Experimental,                     // Code state
+    Tags::GL,                                    // Tags
+};
+const ProcessorInfo VolumeChannelSplitGLProcessor::getProcessorInfo() const {
+    return processorInfo_;
+}
+
+VolumeChannelSplitGLProcessor::VolumeChannelSplitGLProcessor()
+    : Processor()
+    , volumeInport_("volumeInport")
+    , volumeOutport_("volumeOutport"){
+
+    addPorts(volumeInport_, volumeOutport_);
+}
+
+void VolumeChannelSplitGLProcessor::process() {
+    if (!volumeInport_.hasData() || !volumeInport_.getData()) {
+        return;
+    }
+    
+    volumeOutport_.setData(volumeChannelSplitGl_.split(volumeInport_.getData()));
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
@@ -35,7 +35,7 @@ namespace inviwo {
 const ProcessorInfo VolumeChannelSplitGLProcessor::processorInfo_{
     "org.inviwo.VolumeChannelSplitGLProcessor",  // Class identifier
     "Volume Channel Split Processor",            // Display name
-    "Volume Operation",                             // Category
+    "Volume Operation",                          // Category
     CodeState::Experimental,                     // Code state
     Tags::GL,                                    // Tags
 };
@@ -44,9 +44,7 @@ const ProcessorInfo VolumeChannelSplitGLProcessor::getProcessorInfo() const {
 }
 
 VolumeChannelSplitGLProcessor::VolumeChannelSplitGLProcessor()
-    : Processor()
-    , volumeInport_("volumeInport")
-    , volumeOutport_("volumeOutport"){
+    : Processor(), volumeInport_("volumeInport"), volumeOutport_("volumeOutport") {
 
     addPorts(volumeInport_, volumeOutport_);
 }
@@ -55,7 +53,7 @@ void VolumeChannelSplitGLProcessor::process() {
     if (!volumeInport_.hasData() || !volumeInport_.getData()) {
         return;
     }
-    
+
     volumeOutport_.setData(volumeChannelSplitGl_.split(volumeInport_.getData()));
 }
 

--- a/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumechannelsplitglprocessor.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
@@ -35,8 +35,8 @@ namespace inviwo {
 // The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
 const ProcessorInfo VolumeMinMaxGLProcessor::processorInfo_{
     "org.inviwo.VolumeMinMaxGLProcessor",  // Class identifier
-    "Volume Min Max",         // Display name
-    "Volume Operation",                       // Category
+    "Volume Min Max",                      // Display name
+    "Volume Operation",                    // Category
     CodeState::Experimental,               // Code state
     "range, minmax",                       // Tags
 };
@@ -46,8 +46,9 @@ VolumeMinMaxGLProcessor::VolumeMinMaxGLProcessor()
     : Processor()
     , volumeInport_("volumeInport")
     , volumeOutport_("volumeOutport")
-    , disregardingStatus_("disregardingStatus", "Disregarding status",
-                      {{"off", "Off", DisregardingStatus::Off}, {"on", "On", DisregardingStatus::On}})
+    , disregardingStatus_(
+          "disregardingStatus", "Disregarding status",
+          {{"off", "Off", DisregardingStatus::Off}, {"on", "On", DisregardingStatus::On}})
     , disregardingRange_("range", "Range") {
 
     addPorts(volumeInport_, volumeOutport_);

--- a/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
@@ -1,0 +1,86 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/processors/volumeminmaxglprocessor.h>
+#include <inviwo/core/network/networklock.h>
+
+namespace inviwo {
+
+// The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
+const ProcessorInfo VolumeMinMaxGLProcessor::processorInfo_{
+    "org.inviwo.VolumeMinMaxGLProcessor",  // Class identifier
+    "Volume Min Max",         // Display name
+    "Volume Operation",                       // Category
+    CodeState::Experimental,               // Code state
+    "range, minmax",                       // Tags
+};
+const ProcessorInfo VolumeMinMaxGLProcessor::getProcessorInfo() const { return processorInfo_; }
+
+VolumeMinMaxGLProcessor::VolumeMinMaxGLProcessor()
+    : Processor()
+    , volumeInport_("volumeInport")
+    , volumeOutport_("volumeOutport")
+    , disregardingStatus_("disregardingStatus", "Disregarding status",
+                      {{"off", "Off", DisregardingStatus::Off}, {"on", "On", DisregardingStatus::On}})
+    , disregardingRange_("range", "Range") {
+
+    addPorts(volumeInport_, volumeOutport_);
+
+    disregardingRange_.visibilityDependsOn(disregardingStatus_, [](Property& prop) {
+        const auto status = dynamic_cast<TemplateOptionProperty<DisregardingStatus>&>(prop).get();
+
+        return status == DisregardingStatus::On;
+    });
+
+    addProperties(disregardingStatus_, disregardingRange_);
+
+    volumeInport_.onChange([this]() {
+        /*
+         * Here we call the volume reduction without any disregarding so we get the real min and max
+         * values.
+         */
+        const auto range = vec2{volumeMinMaxGl_.minmax(volumeInport_.getData())};
+
+        NetworkLock l;
+
+        disregardingRange_.setRangeMin(range.x);
+        disregardingRange_.setRangeMax(range.y);
+        disregardingRange_.set(range);
+    });
+}
+
+void VolumeMinMaxGLProcessor::process() {
+    auto outVolume = std::shared_ptr<Volume>(volumeInport_.getData()->clone());
+    outVolume->dataMap_.dataRange = outVolume->dataMap_.valueRange = volumeMinMaxGl_.minmax(
+        volumeInport_.getData(), disregardingStatus_.get(), disregardingRange_.get());
+
+    volumeOutport_.setData(outVolume);
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeminmaxglprocessor.cpp
@@ -82,23 +82,19 @@ VolumeMinMaxGLProcessor::VolumeMinMaxGLProcessor()
     });
 
     addProperties(disregardingStatus_, disregardingRange_);
-
-    volumeInport_.onChange([this]() {
-        /*
-         * Here we call the volume reduction without any disregarding so we get the real min and max
-         * values.
-         */
-        const auto range = vec2{volumeMinMaxGl_.minmax(volumeInport_.getData())};
-
-        NetworkLock l;
-
-        disregardingRange_.setRangeMin(range.x);
-        disregardingRange_.setRangeMax(range.y);
-        disregardingRange_.set(range);
-    });
 }
 
 void VolumeMinMaxGLProcessor::process() {
+    if (volumeInport_.isChanged()) {
+        // Here we call the volume reduction without any disregarding so we get the real min and max
+        // values.
+        const NetworkLock l;        
+        const auto range = vec2{volumeMinMaxGl_.minmax(volumeInport_.getData())};
+        disregardingRange_.setRangeMin(range.x);
+        disregardingRange_.setRangeMax(range.y);
+        disregardingRange_.set(range);
+    }
+
     auto outVolume = std::shared_ptr<Volume>(volumeInport_.getData()->clone());
     outVolume->dataMap.dataRange = outVolume->dataMap.valueRange = volumeMinMaxGl_.minmax(
         volumeInport_.getData(), disregardingStatus_.get(), disregardingRange_.get());

--- a/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
@@ -1,0 +1,118 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#include <inviwo/computeutils/processors/volumenormalizationglprocessor.h>
+#include <inviwo/core/network/networklock.h>
+
+namespace inviwo {
+
+// The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
+const ProcessorInfo VolumeNormalizationGLProcessor::processorInfo_{
+    "org.inviwo.VolumeNormalizationGLProcessor",  // Class identifier
+    "Volume Normalization",                       // Display name
+    "Volume Operation",                           // Category
+    CodeState::Stable,                            // Code state
+    Tags::GL,                                     // Tags
+};
+const ProcessorInfo VolumeNormalizationGLProcessor::getProcessorInfo() const {
+    return processorInfo_;
+}
+
+VolumeNormalizationGLProcessor::VolumeNormalizationGLProcessor()
+    : Processor()
+    , volumeInport_("volumeInport")
+    , volumeOutport_("volumeOutport")
+    , channels_("channels", "Channels")
+    , normalizeChannel0_("normalizeChannel0", "Channel 1", true)
+    , normalizeChannel1_("normalizeChannel1", "Channel 2", false)
+    , normalizeChannel2_("normalizeChannel2", "Channel 3", false)
+    , normalizeChannel3_("normalizeChannel3", "Channel 4", false)
+    , volumeNormalization_([&]() { this->invalidate(InvalidationLevel::InvalidOutput); }) {
+
+    addPorts(volumeInport_, volumeOutport_);
+
+    normalizeChannel1_.setVisible(false);
+    normalizeChannel2_.setVisible(false);
+    normalizeChannel3_.setVisible(false);
+
+    channels_.addProperties(normalizeChannel0_, normalizeChannel1_, normalizeChannel2_,
+                            normalizeChannel3_);
+
+    addProperties(channels_);
+
+    volumeInport_.onChange([this]() {
+        if (volumeInport_.hasData()) {
+            auto volume = volumeInport_.getData();
+
+            const auto channels = static_cast<int>(volume->getDataFormat()->getComponents());
+            if (channels == static_cast<int>(channels_.getProperties().size())) return;
+
+            auto properties = channels_.getProperties();
+
+            dynamic_cast<BoolProperty*>(properties[0])->set(true);
+
+            for (int i = 1; i < 4; i++) {
+                auto boolProp = dynamic_cast<BoolProperty*>(properties[i]);
+                boolProp->set(i < channels);
+                boolProp->setVisible(i < channels);
+            }
+
+            volumeNormalization_.reset();
+        }
+    });
+
+    normalizeChannel0_.onChange(
+        [this]() { volumeNormalization_.setNormalizeChannel(0, normalizeChannel0_.get()); });
+    normalizeChannel1_.onChange(
+        [this]() { volumeNormalization_.setNormalizeChannel(1, normalizeChannel1_.get()); });
+    normalizeChannel2_.onChange(
+        [this]() { volumeNormalization_.setNormalizeChannel(2, normalizeChannel2_.get()); });
+    normalizeChannel3_.onChange(
+        [this]() { volumeNormalization_.setNormalizeChannel(3, normalizeChannel3_.get()); });
+}
+
+void VolumeNormalizationGLProcessor::process() {
+    auto inputVolume = volumeInport_.getData();
+    auto channelProperties = channels_.getProperties();
+
+    bool apply = false;
+    for (size_t i{0}; i < channelProperties.size(); ++i) {
+        apply = apply || dynamic_cast<BoolProperty*>(channelProperties[i])->get();
+    }
+    if (inputVolume->getDataFormat()->getNumericType() != NumericType::Float) {
+        LogWarn("Numeric type of input volume is not floating point.");
+    }
+
+    if (!apply) {
+        volumeOutport_.setData(inputVolume);
+    } else {
+        volumeOutport_.setData(volumeNormalization_.normalize(*inputVolume));
+    }
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
@@ -39,7 +39,7 @@ const ProcessorInfo VolumeNormalizationGLProcessor::processorInfo_{
     CodeState::Stable,                            // Code state
     Tags::GL,                                     // Tags
 };
-const ProcessorInfo VolumeNormalizationGLProcessor::getProcessorInfo() const {
+const ProcessorInfo& VolumeNormalizationGLProcessor::getProcessorInfo() const {
     return processorInfo_;
 }
 

--- a/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
@@ -38,21 +38,25 @@ const ProcessorInfo VolumeNormalizationGLProcessor::processorInfo_{
     "Volume Operation",                           // Category
     CodeState::Stable,                            // Code state
     Tags::GL,                                     // Tags
+    R"( Normalizes the selected channels of the input volume to range [0,1].
+    Note that this algorithm normalizes channels independently, it does not 
+    normalize a multi-channel volume in terms of vector norms!)"_unindentHelp,
 };
 const ProcessorInfo& VolumeNormalizationGLProcessor::getProcessorInfo() const {
     return processorInfo_;
 }
 
 VolumeNormalizationGLProcessor::VolumeNormalizationGLProcessor()
-    : Processor()
-    , volumeInport_("volumeInport")
-    , volumeOutport_("volumeOutport")
-    , channels_("channels", "Channels")
-    , normalizeChannel0_("normalizeChannel0", "Channel 1", true)
-    , normalizeChannel1_("normalizeChannel1", "Channel 2", false)
-    , normalizeChannel2_("normalizeChannel2", "Channel 3", false)
-    , normalizeChannel3_("normalizeChannel3", "Channel 4", false)
-    , volumeNormalization_([&]() { this->invalidate(InvalidationLevel::InvalidOutput); }) {
+    : Processor{}
+    , volumeInport_{"volumeInport", "Input Volume"_help}
+    , volumeOutport_{"volumeOutport", "Normalized volume"_help}
+    , channels_{"channels", "Channels",
+                "Select the channels you wish to normalize to range [0,1]"_help}
+    , normalizeChannel0_{"normalizeChannel0", "Channel 1", true}
+    , normalizeChannel1_{"normalizeChannel1", "Channel 2", false}
+    , normalizeChannel2_{"normalizeChannel2", "Channel 3", false}
+    , normalizeChannel3_{"normalizeChannel3", "Channel 4", false}
+    , volumeNormalization_{[this]() { this->invalidate(InvalidationLevel::InvalidOutput); }} {
 
     addPorts(volumeInport_, volumeOutport_);
 

--- a/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
@@ -29,6 +29,8 @@
 #include <inviwo/computeutils/processors/volumenormalizationglprocessor.h>
 #include <inviwo/core/network/networklock.h>
 
+#include <ranges>
+
 namespace inviwo {
 
 // The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
@@ -52,70 +54,48 @@ VolumeNormalizationGLProcessor::VolumeNormalizationGLProcessor()
     , volumeOutport_{"volumeOutport", "Normalized volume"_help}
     , channels_{"channels", "Channels",
                 "Select the channels you wish to normalize to range [0,1]"_help}
-    , normalizeChannel0_{"normalizeChannel0", "Channel 1", true}
-    , normalizeChannel1_{"normalizeChannel1", "Channel 2", false}
-    , normalizeChannel2_{"normalizeChannel2", "Channel 3", false}
-    , normalizeChannel3_{"normalizeChannel3", "Channel 4", false}
-    , volumeNormalization_{[this]() { this->invalidate(InvalidationLevel::InvalidOutput); }} {
+    , normalizeChannel_{{{"normalizeChannel0", "Channel 1", true},
+                         {"normalizeChannel1", "Channel 2", false},
+                         {"normalizeChannel2", "Channel 3", false},
+                         {"normalizeChannel3", "Channel 4", false}}}
+    , volumeNormalization_{[this]() { invalidate(InvalidationLevel::InvalidOutput); }} {
 
     addPorts(volumeInport_, volumeOutport_);
 
-    normalizeChannel1_.setVisible(false);
-    normalizeChannel2_.setVisible(false);
-    normalizeChannel3_.setVisible(false);
-
-    channels_.addProperties(normalizeChannel0_, normalizeChannel1_, normalizeChannel2_,
-                            normalizeChannel3_);
-
+    for (auto& p : normalizeChannel_) {
+        channels_.addProperty(p);
+    }
     addProperties(channels_);
-
-    volumeInport_.onChange([this]() {
-        if (volumeInport_.hasData()) {
-            auto volume = volumeInport_.getData();
-
-            const auto channels = static_cast<int>(volume->getDataFormat()->getComponents());
-            if (channels == static_cast<int>(channels_.getProperties().size())) return;
-
-            auto properties = channels_.getProperties();
-
-            dynamic_cast<BoolProperty*>(properties[0])->set(true);
-
-            for (int i = 1; i < 4; i++) {
-                auto boolProp = dynamic_cast<BoolProperty*>(properties[i]);
-                boolProp->set(i < channels);
-                boolProp->setVisible(i < channels);
-            }
-
-            volumeNormalization_.reset();
-        }
-    });
-
-    normalizeChannel0_.onChange(
-        [this]() { volumeNormalization_.setNormalizeChannel(0, normalizeChannel0_.get()); });
-    normalizeChannel1_.onChange(
-        [this]() { volumeNormalization_.setNormalizeChannel(1, normalizeChannel1_.get()); });
-    normalizeChannel2_.onChange(
-        [this]() { volumeNormalization_.setNormalizeChannel(2, normalizeChannel2_.get()); });
-    normalizeChannel3_.onChange(
-        [this]() { volumeNormalization_.setNormalizeChannel(3, normalizeChannel3_.get()); });
 }
 
 void VolumeNormalizationGLProcessor::process() {
-    auto inputVolume = volumeInport_.getData();
-    auto channelProperties = channels_.getProperties();
+    if (volumeInport_.isChanged() && volumeInport_.hasData()) {
+        auto volume = volumeInport_.getData();
 
-    bool apply = false;
-    for (size_t i{0}; i < channelProperties.size(); ++i) {
-        apply = apply || dynamic_cast<BoolProperty*>(channelProperties[i])->get();
+        const auto channels = static_cast<int>(volume->getDataFormat()->getComponents());
+        if (channels == static_cast<int>(channels_.getProperties().size())) return;
+
+        for (auto&& [index, p] : normalizeChannel_ | std::views::enumerate) {
+            p.set(index < channels);
+        }
+        volumeNormalization_.reset();
     }
+    for (auto&& [index, p] :
+         normalizeChannel_ | std::views::enumerate |
+             std::views::filter([](auto v) { return std::get<1>(v).isModified(); })) {
+        volumeNormalization_.setNormalizeChannel(index, p);
+    }
+
+    auto inputVolume = volumeInport_.getData();
+
     if (inputVolume->getDataFormat()->getNumericType() != NumericType::Float) {
         log::warn("Numeric type of input volume is not floating point.");
     }
 
-    if (!apply) {
-        volumeOutport_.setData(inputVolume);
-    } else {
+    if (std::ranges::any_of(normalizeChannel_, [](const auto& p) { return p.get(); })) {
         volumeOutport_.setData(volumeNormalization_.normalize(*inputVolume));
+    } else {
+        volumeOutport_.setData(inputVolume);
     }
 }
 

--- a/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumenormalizationglprocessor.cpp
@@ -109,7 +109,7 @@ void VolumeNormalizationGLProcessor::process() {
         apply = apply || dynamic_cast<BoolProperty*>(channelProperties[i])->get();
     }
     if (inputVolume->getDataFormat()->getNumericType() != NumericType::Float) {
-        LogWarn("Numeric type of input volume is not floating point.");
+        log::warn("Numeric type of input volume is not floating point.");
     }
 
     if (!apply) {

--- a/misc/computeutils/src/processors/volumereductionglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumereductionglprocessor.cpp
@@ -1,0 +1,64 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/computeutils/processors/volumereductionglprocessor.h>
+
+namespace inviwo {
+
+// The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
+const ProcessorInfo VolumeReductionGLProcessor::processorInfo_{
+    "org.inviwo.VolumeReductionGLProcessor",  // Class identifier
+    "Volume Reduction",                       // Display name
+    "Volume Operation",                          // Category
+    CodeState::Experimental,                  // Code state
+    Tags::GL,                                 // Tags
+};
+const ProcessorInfo VolumeReductionGLProcessor::getProcessorInfo() const { return processorInfo_; }
+
+VolumeReductionGLProcessor::VolumeReductionGLProcessor()
+    : Processor()
+    , volumeInport_("volumeInport")
+    , volumeOutport_("volumeOutport")
+    , reductionOperator_("reductionOperator", "Reduction operator",
+                         {{"min", "Min", ReductionOperator::Min},
+                          {"max", "Max", ReductionOperator::Max},
+                          {"sum", "Sum", ReductionOperator::Sum}}) {
+
+    addPorts(volumeInport_, volumeOutport_);
+
+    addProperties(reductionOperator_);
+}
+
+void VolumeReductionGLProcessor::process() {
+    const auto reduced = gpuReduction_.reduce(volumeInport_.getData(), reductionOperator_.get());
+    
+    volumeOutport_.setData(reduced);
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/processors/volumereductionglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumereductionglprocessor.cpp
@@ -35,7 +35,7 @@ namespace inviwo {
 const ProcessorInfo VolumeReductionGLProcessor::processorInfo_{
     "org.inviwo.VolumeReductionGLProcessor",  // Class identifier
     "Volume Reduction",                       // Display name
-    "Volume Operation",                          // Category
+    "Volume Operation",                       // Category
     CodeState::Experimental,                  // Code state
     Tags::GL,                                 // Tags
 };
@@ -57,7 +57,7 @@ VolumeReductionGLProcessor::VolumeReductionGLProcessor()
 
 void VolumeReductionGLProcessor::process() {
     const auto reduced = gpuReduction_.reduce(volumeInport_.getData(), reductionOperator_.get());
-    
+
     volumeOutport_.setData(reduced);
 }
 

--- a/misc/computeutils/src/processors/volumereductionglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumereductionglprocessor.cpp
@@ -39,7 +39,7 @@ const ProcessorInfo VolumeReductionGLProcessor::processorInfo_{
     CodeState::Experimental,                  // Code state
     Tags::GL,                                 // Tags
 };
-const ProcessorInfo VolumeReductionGLProcessor::getProcessorInfo() const { return processorInfo_; }
+const ProcessorInfo& VolumeReductionGLProcessor::getProcessorInfo() const { return processorInfo_; }
 
 VolumeReductionGLProcessor::VolumeReductionGLProcessor()
     : Processor()

--- a/misc/computeutils/src/processors/volumereductionglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumereductionglprocessor.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
@@ -37,7 +37,10 @@ const ProcessorInfo VolumeShrinkToNormalRangeGLProcessor::processorInfo_{
     "Volume Shrink to Normal Range",                    // Display name
     "Volume Operation",                                 // Category
     CodeState::Stable,                                  // Code state
-    "range, normal, shrink, feature",                   // Tags
+    Tags::GL | Tag{"Normalization"},                    // Tags
+    R"(Shrinks the selected channels of the input volume to range 
+    [0 + offset, 1 + offset] where offset is the percentual deviaton of the minimum 
+    from 0. For example, range [-0.5, 1.0] will be shrunk to [-0.33, 0.66].)"_unindentHelp,
 };
 const ProcessorInfo& VolumeShrinkToNormalRangeGLProcessor::getProcessorInfo() const {
     return processorInfo_;
@@ -45,14 +48,15 @@ const ProcessorInfo& VolumeShrinkToNormalRangeGLProcessor::getProcessorInfo() co
 
 VolumeShrinkToNormalRangeGLProcessor::VolumeShrinkToNormalRangeGLProcessor()
     : Processor()
-    , volumeInport_("volumeInport")
-    , volumeOutport_("volumeOutport")
-    , channels_("channels", "Channels")
-    , shrinkChannel0_("shrinkChannel0", "Channel 1", true)
-    , shrinkChannel1_("shrinkChannel1", "Channel 2", false)
-    , shrinkChannel2_("shrinkChannel2", "Channel 3", false)
-    , shrinkChannel3_("shrinkChannel3", "Channel 4", false)
-    , volumeShrinkToNormalRangeGl_([&]() { this->invalidate(InvalidationLevel::InvalidOutput); }) {
+    , volumeInport_{"volumeInport", "Input Volume"_help}
+    , volumeOutport_{"volumeOutport", "Shrunk volume"_help}
+    , channels_{"channels", "Channels",
+                "Select those channels you wish to shrink to range [0 + offset, 1 + offset]"_help}
+    , shrinkChannel0_{"shrinkChannel0", "Channel 1", true}
+    , shrinkChannel1_{"shrinkChannel1", "Channel 2", false}
+    , shrinkChannel2_{"shrinkChannel2", "Channel 3", false}
+    , shrinkChannel3_{"shrinkChannel3", "Channel 4", false}
+    , volumeShrinkToNormalRangeGl_{[&]() { this->invalidate(InvalidationLevel::InvalidOutput); }} {
 
     addPorts(volumeInport_, volumeOutport_);
 

--- a/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
@@ -39,7 +39,7 @@ const ProcessorInfo VolumeShrinkToNormalRangeGLProcessor::processorInfo_{
     CodeState::Stable,                                  // Code state
     "range, normal, shrink, feature",                   // Tags
 };
-const ProcessorInfo VolumeShrinkToNormalRangeGLProcessor::getProcessorInfo() const {
+const ProcessorInfo& VolumeShrinkToNormalRangeGLProcessor::getProcessorInfo() const {
     return processorInfo_;
 }
 

--- a/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
@@ -1,0 +1,117 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#include <inviwo/computeutils/processors/volumeshrinktonormalrangeglprocessor.h>
+#include <inviwo/core/network/networklock.h>
+
+namespace inviwo {
+
+// The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
+const ProcessorInfo VolumeShrinkToNormalRangeGLProcessor::processorInfo_{
+    "org.inviwo.VolumeShrinkToNormalRangeGLProcessor",  // Class identifier
+    "Volume Shrink to Normal Range",                    // Display name
+    "Volume Operation",                                 // Category
+    CodeState::Stable,                                  // Code state
+    "range, normal, shrink, feature",                   // Tags
+};
+const ProcessorInfo VolumeShrinkToNormalRangeGLProcessor::getProcessorInfo() const {
+    return processorInfo_;
+}
+
+VolumeShrinkToNormalRangeGLProcessor::VolumeShrinkToNormalRangeGLProcessor()
+    : Processor()
+    , volumeInport_("volumeInport")
+    , volumeOutport_("volumeOutport")
+    , channels_("channels", "Channels")
+    , shrinkChannel0_("shrinkChannel0", "Channel 1", true)
+    , shrinkChannel1_("shrinkChannel1", "Channel 2", false)
+    , shrinkChannel2_("shrinkChannel2", "Channel 3", false)
+    , shrinkChannel3_("shrinkChannel3", "Channel 4", false)
+    , volumeShrinkToNormalRangeGl_([&]() { this->invalidate(InvalidationLevel::InvalidOutput); }) {
+
+    addPorts(volumeInport_, volumeOutport_);
+
+    shrinkChannel1_.setVisible(false);
+    shrinkChannel2_.setVisible(false);
+    shrinkChannel3_.setVisible(false);
+
+    channels_.addProperties(shrinkChannel0_, shrinkChannel1_, shrinkChannel2_, shrinkChannel3_);
+
+    addProperties(channels_);
+
+    volumeInport_.onChange([this]() {
+        if (volumeInport_.hasData()) {
+            auto volume = volumeInport_.getData();
+
+            const auto channels = static_cast<int>(volume->getDataFormat()->getComponents());
+            if (channels == static_cast<int>(channels_.getProperties().size())) return;
+
+            auto properties = channels_.getProperties();
+
+            dynamic_cast<BoolProperty*>(properties[0])->set(true);
+
+            for (int i = 1; i < 4; i++) {
+                auto boolProp = dynamic_cast<BoolProperty*>(properties[i]);
+                boolProp->set(i < channels);
+                boolProp->setVisible(i < channels);
+            }
+
+            volumeShrinkToNormalRangeGl_.reset();
+        }
+    });
+
+    shrinkChannel0_.onChange(
+        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(0, shrinkChannel0_.get()); });
+    shrinkChannel1_.onChange(
+        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(1, shrinkChannel1_.get()); });
+    shrinkChannel2_.onChange(
+        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(2, shrinkChannel2_.get()); });
+    shrinkChannel3_.onChange(
+        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(3, shrinkChannel3_.get()); });
+}
+
+void VolumeShrinkToNormalRangeGLProcessor::process() {
+    auto inputVolume = volumeInport_.getData();
+    auto channelProperties = channels_.getProperties();
+
+    bool apply = false;
+    for (size_t i{0}; i < channelProperties.size(); ++i) {
+        apply = apply || dynamic_cast<BoolProperty*>(channelProperties[i])->get();
+    }
+    if (inputVolume->getDataFormat()->getNumericType() != NumericType::Float) {
+        LogWarn("Numeric type of input volume is not floating point.");
+    }
+
+    if (!apply) {
+        volumeOutport_.setData(inputVolume);
+    } else {
+        volumeOutport_.setData(volumeShrinkToNormalRangeGl_.shrink(*inputVolume));
+    }
+}
+
+}  // namespace inviwo

--- a/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
@@ -52,54 +52,39 @@ VolumeShrinkToNormalRangeGLProcessor::VolumeShrinkToNormalRangeGLProcessor()
     , volumeOutport_{"volumeOutport", "Shrunk volume"_help}
     , channels_{"channels", "Channels",
                 "Select those channels you wish to shrink to range [0 + offset, 1 + offset]"_help}
-    , shrinkChannel0_{"shrinkChannel0", "Channel 1", true}
-    , shrinkChannel1_{"shrinkChannel1", "Channel 2", false}
-    , shrinkChannel2_{"shrinkChannel2", "Channel 3", false}
-    , shrinkChannel3_{"shrinkChannel3", "Channel 4", false}
-    , volumeShrinkToNormalRangeGl_{[&]() { this->invalidate(InvalidationLevel::InvalidOutput); }} {
+    , shrinkChannel_{{{"shrinkChannel0", "Channel 1", true},
+                      {"shrinkChannel1", "Channel 2", false},
+                      {"shrinkChannel2", "Channel 3", false},
+                      {"shrinkChannel3", "Channel 4", false}}}
+    , volumeShrinkToNormalRangeGl_{[this]() { invalidate(InvalidationLevel::InvalidOutput); }} {
 
     addPorts(volumeInport_, volumeOutport_);
 
-    shrinkChannel1_.setVisible(false);
-    shrinkChannel2_.setVisible(false);
-    shrinkChannel3_.setVisible(false);
-
-    channels_.addProperties(shrinkChannel0_, shrinkChannel1_, shrinkChannel2_, shrinkChannel3_);
-
+    for (auto& p : shrinkChannel_) {
+        channels_.addProperty(p);
+    }
     addProperties(channels_);
-
-    volumeInport_.onChange([this]() {
-        if (volumeInport_.hasData()) {
-            auto volume = volumeInport_.getData();
-
-            const auto channels = static_cast<int>(volume->getDataFormat()->getComponents());
-            if (channels == static_cast<int>(channels_.getProperties().size())) return;
-
-            auto properties = channels_.getProperties();
-
-            dynamic_cast<BoolProperty*>(properties[0])->set(true);
-
-            for (int i = 1; i < 4; i++) {
-                auto boolProp = dynamic_cast<BoolProperty*>(properties[i]);
-                boolProp->set(i < channels);
-                boolProp->setVisible(i < channels);
-            }
-
-            volumeShrinkToNormalRangeGl_.reset();
-        }
-    });
-
-    shrinkChannel0_.onChange(
-        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(0, shrinkChannel0_.get()); });
-    shrinkChannel1_.onChange(
-        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(1, shrinkChannel1_.get()); });
-    shrinkChannel2_.onChange(
-        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(2, shrinkChannel2_.get()); });
-    shrinkChannel3_.onChange(
-        [this]() { volumeShrinkToNormalRangeGl_.setShrinkChannel(3, shrinkChannel3_.get()); });
 }
 
 void VolumeShrinkToNormalRangeGLProcessor::process() {
+    if (volumeInport_.isChanged() && volumeInport_.hasData()) {
+        auto volume = volumeInport_.getData();
+
+        const auto channels = static_cast<int>(volume->getDataFormat()->getComponents());
+        if (channels == static_cast<int>(channels_.getProperties().size())) return;
+
+        for (auto&& [index, p] : shrinkChannel_ | std::views::enumerate) {
+            p.set(index < channels);
+        }
+        volumeShrinkToNormalRangeGl_.reset();
+    }
+    for (auto&& [index, p] :
+         shrinkChannel_ | std::views::enumerate |
+             std::views::filter([](auto v) { return std::get<1>(v).isModified(); })) {
+        volumeShrinkToNormalRangeGl_.setShrinkChannel(index, p);
+    }
+
+
     auto inputVolume = volumeInport_.getData();
     auto channelProperties = channels_.getProperties();
 

--- a/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
+++ b/misc/computeutils/src/processors/volumeshrinktonormalrangeglprocessor.cpp
@@ -108,7 +108,7 @@ void VolumeShrinkToNormalRangeGLProcessor::process() {
         apply = apply || dynamic_cast<BoolProperty*>(channelProperties[i])->get();
     }
     if (inputVolume->getDataFormat()->getNumericType() != NumericType::Float) {
-        LogWarn("Numeric type of input volume is not floating point.");
+        log::warn("Numeric type of input volume is not floating point.");
     }
 
     if (!apply) {

--- a/misc/computeutils/tests/unittests/computeutils-unittest-main.cpp
+++ b/misc/computeutils/tests/unittests/computeutils-unittest-main.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2025 Inviwo Foundation
+ * Copyright (c) 2025-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/misc/computeutils/tests/unittests/computeutils-unittest-main.cpp
+++ b/misc/computeutils/tests/unittests/computeutils-unittest-main.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2025 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,48 +27,31 @@
  *
  *********************************************************************************/
 
-#pragma once
+#ifdef _MSC_VER
+#pragma comment(linker, "/SUBSYSTEM:CONSOLE")
+#endif
 
-#include <inviwo/computeutils/computeutilsmoduledefine.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/computeutils/algorithm/volumereductiongl.h>
-#include <inviwo/core/ports/volumeport.h>
-#include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/util/logcentral.h>
+#include <inviwo/core/util/consolelogger.h>
+#include <inviwo/testutil/configurablegtesteventlistener.h>
 
-namespace inviwo {
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
 
-/** \docpage{org.inviwo.VolumeReductionGLProcessor, Volume Reduction Processor}
- * ![](org.inviwo.VolumeReductionGLProcessor.png?classIdentifier=org.inviwo.VolumeReductionGLProcessor)
- *
- * GL implementation of add, min, and max reductions for 3D textures (volumes).
- *
- * ### Inputs
- *   * __Volume inport__ Input volume.
- *
- * ### Outports
- *   * __Volume outport__ Reduced volume.
- *
- * ### Properties
- *   * __Reduction operator__ Operator for reduction.
- *
- */
-class IVW_MODULE_COMPUTEUTILS_API VolumeReductionGLProcessor : public Processor {
-public:
-    VolumeReductionGLProcessor();
-    virtual ~VolumeReductionGLProcessor() = default;
+int main(int argc, char** argv) {
+    using namespace inviwo;
+    LogCentral::init();
+    auto logger = std::make_shared<ConsoleLogger>();
+    LogCentral::getPtr()->setVerbosity(LogVerbosity::Error);
+    LogCentral::getPtr()->registerLogger(logger);
 
-    virtual void process() override;
-
-    virtual const ProcessorInfo& getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
-
-private:
-    VolumeInport volumeInport_;
-    VolumeOutport volumeOutport_;
-
-    OptionProperty<ReductionOperator> reductionOperator_;
-
-    VolumeReductionGL gpuReduction_;
-};
-
-}  // namespace inviwo
+    int ret = -1;
+    {
+        ::testing::InitGoogleTest(&argc, argv);
+        inviwo::ConfigurableGTestEventListener::setup();
+        ret = RUN_ALL_TESTS();
+    }
+    return ret;
+}

--- a/multivis/featurelevelsetsgl/CMakeLists.txt
+++ b/multivis/featurelevelsetsgl/CMakeLists.txt
@@ -1,0 +1,40 @@
+ivw_module(FeatureLevelSetsGL)
+
+set(HEADER_FILES
+    include/inviwo/featurelevelsetsgl/featurelevelsetsglmodule.h
+    include/inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h
+    include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
+    include/inviwo/featurelevelsetsgl/properties/traitproperty.h
+    include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
+    include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
+    include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
+    include/inviwo/featurelevelsetsgl/util/util.h
+)
+ivw_group("Header Files" ${HEADER_FILES})
+
+set(SOURCE_FILES
+    src/featurelevelsetsglmodule.cpp
+    src/processors/featurelevelsetprocessorgl.cpp
+    src/properties/traitproperty.cpp
+    src/properties/implicitfunctiontraitproperty.cpp
+    src/properties/pointtraitproperty.cpp
+    src/properties/rangetraitproperty.cpp
+)
+ivw_group("Source Files" ${SOURCE_FILES})
+
+set(SHADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/glsl/featurelevelsets.comp
+    ${CMAKE_CURRENT_SOURCE_DIR}/glsl/pointtrait.glsl
+    ${CMAKE_CURRENT_SOURCE_DIR}/glsl/rangetrait.glsl
+)
+ivw_group("Shader Files" ${SHADER_FILES})
+
+set(TEST_FILES
+    tests/unittests/featurelevelsetsgl-unittest-main.cpp
+)
+ivw_add_unittest(${TEST_FILES})
+
+ivw_create_module(${SOURCE_FILES} ${HEADER_FILES} ${SHADER_FILES})
+
+# Add shader directory to install package
+#ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/glsl)

--- a/multivis/featurelevelsetsgl/CMakeLists.txt
+++ b/multivis/featurelevelsetsgl/CMakeLists.txt
@@ -36,5 +36,4 @@ ivw_add_unittest(${TEST_FILES})
 
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES} ${SHADER_FILES})
 
-# Add shader directory to install package
-#ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/glsl)
+ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/glsl)

--- a/multivis/featurelevelsetsgl/depends.cmake
+++ b/multivis/featurelevelsetsgl/depends.cmake
@@ -1,0 +1,5 @@
+set(dependencies
+    InviwoBaseGLModule
+    InviwoOpenGLModule # Example dependency 
+    InviwoComputeUtilsModule
+)

--- a/multivis/featurelevelsetsgl/glsl/featurelevelsets.comp
+++ b/multivis/featurelevelsetsgl/glsl/featurelevelsets.comp
@@ -1,0 +1,102 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include "utils/structs.glsl"
+#include "pointtrait.glsl"
+#include "rangetrait.glsl"
+
+uniform VolumeParameters volumeParameters[NUM_VOLUMES];
+
+uniform sampler3D volume[NUM_VOLUMES];
+
+writeonly uniform image3D dest;
+
+uniform vec4 pointTraits[TRAIT_ALLOCATION];
+uniform mat4 rangeTraits[TRAIT_ALLOCATION];
+
+uniform vec2 volumeRanges[NUM_VOLUMES];
+
+uniform int numPointTraits;
+uniform int numRangeTraits;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+// #define ENABLE_IMPLICIT_FUNCTION_1
+void implicitFunction1(in float point[NUM_VOLUMES], in vec2[NUM_VOLUMES] ranges, out float result) {
+    // #IMPLICIT_FUNCTION_1
+}
+
+// #define ENABLE_IMPLICIT_FUNCTION_2
+void implicitFunction2(in float point[NUM_VOLUMES], in vec2[NUM_VOLUMES] ranges, out float result) {
+    // #IMPLICIT_FUNCTION_2
+}
+
+// #define ENABLE_IMPLICIT_FUNCTION_3
+void implicitFunction3(in float point[NUM_VOLUMES], in vec2[NUM_VOLUMES] ranges, out float result) {
+    // #IMPLICIT_FUNCTION_3
+}
+
+void main() {
+    ivec3 storePos = ivec3(gl_GlobalInvocationID);
+
+    ivec3 dims = textureSize(volume[0], 0);
+
+    float point[NUM_VOLUMES];
+
+    for (int i = 0; i < NUM_VOLUMES; i++) {
+        vec4 dimensionValue = texelFetch(volume[i], storePos, 0);
+
+        point[i] = dimensionValue.r;
+    }
+
+    float pointDist = minDistanceToSetOfPointTraits(point, pointTraits, numPointTraits);
+    float rangeDist = minDistanceToSetOfRangeTraits(point, rangeTraits, numRangeTraits);
+
+    float result = min(pointDist, rangeDist);
+
+#ifdef ENABLE_IMPLICIT_FUNCTION_1
+    float res = 1.0 / 0.0;
+    implicitFunction1(point, volumeRanges, res);
+    result = min(result, res);
+#endif
+
+#ifdef ENABLE_IMPLICIT_FUNCTION_2
+    float res = 1.0 / 0.0;
+    implicitFunction2(point, volumeRanges, res);
+    result = min(result, res);
+#endif
+
+#ifdef ENABLE_IMPLICIT_FUNCTION_3
+    float res = 1.0 / 0.0;
+    implicitFunction3(point, volumeRanges, res);
+    result = min(result, res);
+#endif
+
+    imageStore(dest, storePos, vec4(result));
+}

--- a/multivis/featurelevelsetsgl/glsl/featurelevelsets.comp
+++ b/multivis/featurelevelsetsgl/glsl/featurelevelsets.comp
@@ -27,6 +27,16 @@
  *
  *********************************************************************************/
 
+#if !defined(IMPLICIT_FUNCTION_1)
+#define IMPLICIT_FUNCTION_1
+#endif
+#if !defined(IMPLICIT_FUNCTION_2)
+#define IMPLICIT_FUNCTION_2
+#endif
+#if !defined(IMPLICIT_FUNCTION_3)
+#define IMPLICIT_FUNCTION_3
+#endif
+
 #include "utils/structs.glsl"
 #include "pointtrait.glsl"
 #include "rangetrait.glsl"
@@ -47,19 +57,16 @@ uniform int numRangeTraits;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-// #define ENABLE_IMPLICIT_FUNCTION_1
 void implicitFunction1(in float point[NUM_VOLUMES], in vec2[NUM_VOLUMES] ranges, out float result) {
-    // #IMPLICIT_FUNCTION_1
+    IMPLICIT_FUNCTION_1
 }
 
-// #define ENABLE_IMPLICIT_FUNCTION_2
 void implicitFunction2(in float point[NUM_VOLUMES], in vec2[NUM_VOLUMES] ranges, out float result) {
-    // #IMPLICIT_FUNCTION_2
+    IMPLICIT_FUNCTION_2
 }
 
-// #define ENABLE_IMPLICIT_FUNCTION_3
 void implicitFunction3(in float point[NUM_VOLUMES], in vec2[NUM_VOLUMES] ranges, out float result) {
-    // #IMPLICIT_FUNCTION_3
+    IMPLICIT_FUNCTION_3
 }
 
 void main() {

--- a/multivis/featurelevelsetsgl/glsl/featurelevelsets.comp
+++ b/multivis/featurelevelsetsgl/glsl/featurelevelsets.comp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/glsl/pointtrait.glsl
+++ b/multivis/featurelevelsetsgl/glsl/pointtrait.glsl
@@ -1,0 +1,34 @@
+/*
+Available macros:
+    NUM_VOLUMES:      The number of input volumes, corresponds to the dimensionality of the attribute space
+    TRAIT_ALLOCATION: Maximum number of traits
+*/
+
+/*
+* Calculates the euclidean distance of an n-dimensional point to an n-dimensional point trait.
+*/
+float euclideanDistanceToPointTrait(float point[NUM_VOLUMES], vec4 trait) {
+  float dist = 0.0f;
+
+  for(int i = 0; i < NUM_VOLUMES; i++) {
+    float diff = point[i] - trait[i];
+    dist += diff * diff;
+  }
+
+#ifdef SQUARED_DISTANCE
+  return dist;
+#else
+  return sqrt(dist);
+#endif
+}
+
+float minDistanceToSetOfPointTraits(float point[NUM_VOLUMES], vec4 traits[TRAIT_ALLOCATION], int numPointTraits) {
+  float minDistance = 1.0f / 0.0f;
+
+  for (int i = 0; i < numPointTraits; i++) {
+    vec4 trait = traits[i];
+    minDistance = min(euclideanDistanceToPointTrait(point, trait), minDistance);
+  }
+
+  return minDistance;
+}

--- a/multivis/featurelevelsetsgl/glsl/rangetrait.glsl
+++ b/multivis/featurelevelsetsgl/glsl/rangetrait.glsl
@@ -1,0 +1,37 @@
+/*
+Available macros:
+    NUM_VOLUMES:      The number of input volumes, corresponds to the dimensionality of the attribute space
+    TRAIT_ALLOCATION: Maximum number of traits
+*/
+
+/*
+* Calculates the euclidean distance of an n-dimensional point to an n-dimensional range trait.
+*/
+float euclideanDistanceToRangeTrait(float point[NUM_VOLUMES], mat4 trait) {
+  /*
+  float dist = 0.0f;
+
+  for(int i = 0; i < NUM_VOLUMES; i++) {
+    float diff = point[i] - trait[i];
+    dist += diff * diff;
+  }
+
+#ifdef SQUARED_DISTANCE
+  return dist;
+#else
+  return sqrt(dist);
+#endif
+*/
+  return 0;
+}
+
+float minDistanceToSetOfRangeTraits(float point[NUM_VOLUMES], mat4 traits[TRAIT_ALLOCATION], int numPointTraits) {
+  float minDistance = 1.0f / 0.0f;
+
+  for (int i = 0; i < numPointTraits; i++) {
+    mat4 trait = traits[i];
+    minDistance = min(euclideanDistanceToRangeTrait(point, trait), minDistance);
+  }
+
+  return minDistance;
+}

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/featurelevelsetsglmodule.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/featurelevelsetsglmodule.h
@@ -1,0 +1,42 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
+#include <inviwo/core/common/inviwomodule.h>
+
+namespace inviwo {
+
+class IVW_MODULE_FEATURELEVELSETSGL_API FeatureLevelSetsGLModule : public InviwoModule {
+public:
+    FeatureLevelSetsGLModule(InviwoApplication* app);
+    virtual ~FeatureLevelSetsGLModule() = default;
+};
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/featurelevelsetsglmodule.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/featurelevelsetsglmodule.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// clang-format off
+#ifdef INVIWO_ALL_DYN_LINK  //DYNAMIC
+	// If we are building DLL files we must declare dllexport/dllimport
+	#ifdef IVW_MODULE_FEATURELEVELSETSGL_EXPORTS
+		#ifdef _WIN32
+			#define IVW_MODULE_FEATURELEVELSETSGL_API __declspec(dllexport)
+		#else  //UNIX (GCC)
+			#define IVW_MODULE_FEATURELEVELSETSGL_API __attribute__ ((visibility ("default")))
+		#endif
+	#else
+		#ifdef _WIN32
+			#define IVW_MODULE_FEATURELEVELSETSGL_API __declspec(dllimport)
+		#else
+			#define IVW_MODULE_FEATURELEVELSETSGL_API
+		#endif
+	#endif
+#else  //STATIC
+	#define IVW_MODULE_FEATURELEVELSETSGL_API
+#endif
+// clang-format on

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
@@ -1,0 +1,132 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/ports/volumeport.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/properties/listproperty.h>
+#include <inviwo/core/properties/propertyownerobserver.h>
+#include <inviwo/computeutils/algorithm/volumereductiongl.h>
+#include <inviwo/computeutils/algorithm/volumenormalizationgl.h>
+#include <inviwo/core/properties/buttonproperty.h>
+
+namespace inviwo {
+
+/** \docpage{org.inviwo.FeatureLevelSetProcessorGL, Feature Level Set Processor}
+ * ![](org.inviwo.FeatureLevelSetProcessorGL.png?classIdentifier=org.inviwo.FeatureLevelSetProcessorGL)
+ */
+class IVW_MODULE_FEATURELEVELSETSGL_API FeatureLevelSetProcessorGL : public Processor,
+                                                                     public PropertyOwnerObserver
+
+{
+public:
+    FeatureLevelSetProcessorGL();
+    virtual ~FeatureLevelSetProcessorGL() = default;
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+    static const ProcessorInfo processorInfo_;
+
+    virtual void serialize(Serializer& s) const final;
+    virtual void deserialize(Deserializer& s) final;
+
+private:
+    // Ports
+    DataInport<Volume, 0, true> volumes_;
+    VolumeOutport distanceVolumeOutport_;
+
+    // Properties
+    BoolProperty squaredDistance_;
+    BoolProperty useVolumesDataMap_;
+    BoolProperty useNormalizedValues_;
+    BoolProperty capMaxDistance_;
+    ListProperty traitPropertiesContainer_;
+    ButtonProperty injectButton_;
+
+    // Caches
+    size_t prevNumberOfVolumes_;
+    std::array<vec2, 4> dataRangesCache_;
+    size_t traitAllocation_{8};
+    std::vector<std::string> volumeNameCache_{};
+    double maxDist_;
+    std::vector<std::pair<std::string, std::shared_ptr<Volume>>> normalizedVolumesCache_;
+
+    // Members
+    Shader shader_;
+    ShaderSegment implicitFunctionSegment_;
+    const size_t maxVolumes_{4};
+    VolumeNormalizationGL normalization_;
+    VolumeReductionGL reduction_;
+
+    // Helpers
+    std::vector<vec4> gatherPointTraits() const;
+    void normalizePointTraits(std::vector<vec4>& pointTraits) const;
+
+    /*
+     * Gathers the point traits to upload to the GPU.
+     * The layout is as follows:
+     * Column defines the dimension in the attribute space
+     * 1st row is the min value
+     * 2nd row is the max value
+     */
+    std::vector<mat4> gatherRangeTraits() const;
+    void normalizeRangeTraits(std::vector<mat4>& rangeTraits) const;
+
+    std::vector<vec2> gatherVolumeRanges() const;
+    void normalizeVolumeRanges(std::vector<vec2>& volumeRanges) const;
+
+    // Code fragments
+    void checkInput() const;
+    void setUniforms();
+    std::shared_ptr<Volume> bindOutputTexture();
+    void gpuDispatch();
+
+    // Updates
+    void updateDataRangesCache();
+    void updateMaximumDistance();
+    void updateNormalizedVolumesCache();
+    void updateVolumeNamesCache();
+
+    /*
+     * Returns true if input volumes have same identifiers as name cache
+     */
+    bool compareInputsToCache() const;
+
+    void resizeTraitAllocation();
+    void initializeAllProperties();
+
+    virtual void onWillAddProperty(Property* property, size_t index) final;
+};
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
@@ -55,7 +55,7 @@ public:
 
     virtual void process() override;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
+    virtual const ProcessorInfo& getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 
     virtual void serialize(Serializer& s) const final;

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
@@ -1,12 +1,42 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/ \
 #pragma once
 
 #include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
 #include <inviwo/featurelevelsetsgl/properties/traitproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
-#include <modules/opengl/shader/shader.h>
-#include <inviwo/core/datastructures/volume/volume.h>
 
 namespace inviwo {
+
+class Shader;
+class Volume;
+
 class IVW_MODULE_FEATURELEVELSETSGL_API ImplicitFunctionTraitProperty : public TraitProperty {
 public:
     static constexpr std::string_view stub{
@@ -28,19 +58,18 @@ public:
         return new ImplicitFunctionTraitProperty(*this);
     }
 
-    virtual std::string getClassIdentifier() const override;
-    static const std::string classIdentifier;
+    std::string_view getClassIdentifier() const override;
+    static constexpr std::string_view classIdentifier{"org.inviwo.ImplicitFunctionTraitProperty"};
 
     virtual ~ImplicitFunctionTraitProperty() = default;
 
     void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
                       bool useVolumeDataMap) final;
 
-    void inject(Shader& shader);
+    void inject(Shader& shader) const;
 
 private:
     StringProperty shaderInjection_;
-    std::string originalShader_;
 };
 
 }  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
+#include <inviwo/featurelevelsetsgl/properties/traitproperty.h>
+#include <inviwo/core/properties/stringproperty.h>
+#include <modules/opengl/shader/shader.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+
+namespace inviwo {
+class IVW_MODULE_FEATURELEVELSETSGL_API ImplicitFunctionTraitProperty : public TraitProperty {
+public:
+    static constexpr std::string_view stub{"// in:  <float> point[NUM_VOLUMES]\n//in:  <vec2> ranges[NUM_VOLUMES]\n// out: <float> result\nresult = point[0];"};
+
+    ImplicitFunctionTraitProperty() = delete;
+    ImplicitFunctionTraitProperty(const ImplicitFunctionTraitProperty& p)
+        : ImplicitFunctionTraitProperty(p.getIdentifier(), p.getDisplayName()) {}
+
+    ImplicitFunctionTraitProperty(const std::string& identifier, const std::string& displayName)
+        : TraitProperty(identifier, displayName)
+        , shaderInjection_("shaderInjection", "Implicit function", std::string(stub),
+                           InvalidationLevel::InvalidOutput, PropertySemantics::ShaderEditor) {
+        addProperties(shaderInjection_);
+    }
+
+    virtual ImplicitFunctionTraitProperty* clone() const final {
+        return new ImplicitFunctionTraitProperty(*this);
+    }
+
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+
+    virtual ~ImplicitFunctionTraitProperty() = default;
+
+    void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+                      bool useVolumeDataMap) final;
+
+    void inject(Shader& shader);
+
+private:
+    StringProperty shaderInjection_;
+    std::string originalShader_;
+};
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
@@ -9,7 +9,9 @@
 namespace inviwo {
 class IVW_MODULE_FEATURELEVELSETSGL_API ImplicitFunctionTraitProperty : public TraitProperty {
 public:
-    static constexpr std::string_view stub{"// in:  <float> point[NUM_VOLUMES]\n//in:  <vec2> ranges[NUM_VOLUMES]\n// out: <float> result\nresult = point[0];"};
+    static constexpr std::string_view stub{
+        "// in:  <float> point[NUM_VOLUMES]\n//in:  <vec2> ranges[NUM_VOLUMES]\n// out: <float> "
+        "result\nresult = point[0];"};
 
     ImplicitFunctionTraitProperty() = delete;
     ImplicitFunctionTraitProperty(const ImplicitFunctionTraitProperty& p)

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h
@@ -44,12 +44,9 @@ public:
         "result\nresult = point[0];"};
 
     ImplicitFunctionTraitProperty() = delete;
-    ImplicitFunctionTraitProperty(const ImplicitFunctionTraitProperty& p)
-        : ImplicitFunctionTraitProperty(p.getIdentifier(), p.getDisplayName()) {}
-
-    ImplicitFunctionTraitProperty(const std::string& identifier, const std::string& displayName)
+    ImplicitFunctionTraitProperty(std::string_view identifier, std::string_view displayName)
         : TraitProperty(identifier, displayName)
-        , shaderInjection_("shaderInjection", "Implicit function", std::string(stub),
+        , shaderInjection_("shaderInjection", "Implicit function", stub,
                            InvalidationLevel::InvalidOutput, PropertySemantics::ShaderEditor) {
         addProperties(shaderInjection_);
     }
@@ -57,13 +54,12 @@ public:
     virtual ImplicitFunctionTraitProperty* clone() const final {
         return new ImplicitFunctionTraitProperty(*this);
     }
+    virtual ~ImplicitFunctionTraitProperty() = default;
 
     std::string_view getClassIdentifier() const override;
     static constexpr std::string_view classIdentifier{"org.inviwo.ImplicitFunctionTraitProperty"};
 
-    virtual ~ImplicitFunctionTraitProperty() = default;
-
-    void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+    void addAttribute(std::string_view name, std::shared_ptr<const Volume> volume,
                       bool useVolumeDataMap) final;
 
     void inject(Shader& shader) const;

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
+#include <inviwo/featurelevelsetsgl/properties/traitproperty.h>
+#include <inviwo/core/properties/ordinalproperty.h>
+
+namespace inviwo {
+class IVW_MODULE_FEATURELEVELSETSGL_API PointTraitProperty : public TraitProperty {
+public:
+    PointTraitProperty() = delete;
+    PointTraitProperty(const PointTraitProperty& p)
+        : TraitProperty(p)
+        , attribute1_(p.attribute1_)
+        , attribute2_(p.attribute2_)
+        , attribute3_(p.attribute3_)
+        , attribute4_(p.attribute4_) {
+
+        attributes_ =
+            std::array<FloatProperty*, 4>{&attribute1_, &attribute2_, &attribute3_, &attribute4_};
+
+        addProperties(attribute1_, attribute2_, attribute3_, attribute4_);
+    }
+
+    PointTraitProperty(const std::string& identifier, const std::string& displayName)
+        : TraitProperty(identifier, displayName)
+        , attribute1_("attribute1", "")
+        , attribute2_("attribute2", "")
+        , attribute3_("attribute3", "")
+        , attribute4_("attribute4", "") {
+
+        attributes_ =
+            std::array<FloatProperty*, 4>{&attribute1_, &attribute2_, &attribute3_, &attribute4_};
+
+        for (auto attribute : attributes_) {
+            attribute->setVisible(false);
+            attribute->setSerializationMode(PropertySerializationMode::All);
+        }
+
+        addProperties(attribute1_, attribute2_, attribute3_, attribute4_);
+    }
+
+    virtual PointTraitProperty* clone() const final { return new PointTraitProperty(*this); }
+
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+
+    virtual ~PointTraitProperty() final = default;
+
+    vec4 getAsVec4() const;
+
+    void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+                      bool useVolumeDataMap) final;
+
+private:
+    FloatProperty attribute1_;
+    FloatProperty attribute2_;
+    FloatProperty attribute3_;
+    FloatProperty attribute4_;
+
+    std::array<FloatProperty*, 4> attributes_;
+};
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
@@ -1,3 +1,31 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
 #pragma once
 
 #include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
@@ -41,8 +69,8 @@ public:
 
     virtual PointTraitProperty* clone() const final { return new PointTraitProperty(*this); }
 
-    virtual std::string getClassIdentifier() const override;
-    static const std::string classIdentifier;
+    virtual std::string_view getClassIdentifier() const override;
+    static constexpr std::string_view classIdentifier{"org.inviwo.PointTraitProperty"};
 
     virtual ~PointTraitProperty() final = default;
 

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/pointtraitproperty.h
@@ -76,7 +76,7 @@ public:
 
     vec4 getAsVec4() const;
 
-    void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+    void addAttribute(std::string_view name, std::shared_ptr<const Volume> volume,
                       bool useVolumeDataMap) final;
 
 private:

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
+#include <inviwo/featurelevelsetsgl/properties/traitproperty.h>
+#include <inviwo/core/properties/minmaxproperty.h>
+
+namespace inviwo {
+class IVW_MODULE_FEATURELEVELSETSGL_API RangeTraitProperty : public TraitProperty {
+public:
+    RangeTraitProperty() = delete;
+    RangeTraitProperty(const RangeTraitProperty& p)
+        : TraitProperty(p)
+        , attribute1_(p.attribute1_)
+        , attribute2_(p.attribute2_)
+        , attribute3_(p.attribute3_)
+        , attribute4_(p.attribute4_) {
+        attributes_ = std::array<FloatMinMaxProperty*, 4>{&attribute1_, &attribute2_, &attribute3_,
+                                                          &attribute4_};
+
+        addProperties(attribute1_, attribute2_, attribute3_, attribute4_);
+    }
+
+    RangeTraitProperty(const std::string& identifier, const std::string& displayName)
+        : TraitProperty(identifier, displayName)
+        , attribute1_("attribute1", "")
+        , attribute2_("attribute2", "")
+        , attribute3_("attribute3", "")
+        , attribute4_("attribute4", "") {
+        attributes_ = std::array<FloatMinMaxProperty*, 4>{&attribute1_, &attribute2_, &attribute3_,
+                                                          &attribute4_};
+
+        for (auto attribute : attributes_) {
+            attribute->setVisible(false);
+            attribute->setSerializationMode(PropertySerializationMode::All);
+        }
+
+        addProperties(attribute1_, attribute2_, attribute3_, attribute4_);
+    }
+
+    virtual RangeTraitProperty* clone() const final { return new RangeTraitProperty(*this); }
+
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+
+    virtual ~RangeTraitProperty() = default;
+
+    mat4 getAsMat4() const;
+
+    void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+                      bool useVolumeDataMap) final;
+
+private:
+    FloatMinMaxProperty attribute1_;
+    FloatMinMaxProperty attribute2_;
+    FloatMinMaxProperty attribute3_;
+    FloatMinMaxProperty attribute4_;
+
+    std::array<FloatMinMaxProperty*, 4> attributes_;
+};
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
@@ -1,3 +1,31 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
 #pragma once
 
 #include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
@@ -39,8 +67,8 @@ public:
 
     virtual RangeTraitProperty* clone() const final { return new RangeTraitProperty(*this); }
 
-    virtual std::string getClassIdentifier() const override;
-    static const std::string classIdentifier;
+    virtual std::string_view getClassIdentifier() const override;
+    static constexpr std::string_view classIdentifier{"org.inviwo.RangeTraitProperty"};
 
     virtual ~RangeTraitProperty() = default;
 

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/rangetraitproperty.h
@@ -74,7 +74,7 @@ public:
 
     mat4 getAsMat4() const;
 
-    void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+    void addAttribute(std::string_view name, std::shared_ptr<const Volume> volume,
                       bool useVolumeDataMap) final;
 
 private:

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
@@ -1,3 +1,31 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
 #pragma once
 
 #include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
@@ -14,13 +42,10 @@ public:
 
     virtual ~TraitProperty() override = default;
 
-    /*
-     * Enforce clone method to enable usage as prefab in list property
-     */
     TraitProperty* clone() const override = 0;
 
-    std::string getClassIdentifier() const override;
-    static const std::string classIdentifier;
+    std::string_view getClassIdentifier() const override;
+    static constexpr std::string_view classIdentifier{"org.inviwo.TraitProperty"};
 
     virtual void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
                               bool useVolumeDataMap) = 0;

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmoduledefine.h>
+#include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+
+namespace inviwo {
+class IVW_MODULE_FEATURELEVELSETSGL_API TraitProperty : public CompositeProperty {
+public:
+    TraitProperty() = delete;
+    TraitProperty(const std::string& identifier, const std::string& displayName)
+        : CompositeProperty(identifier, displayName), numInitializedAttributes_(0) {}
+    TraitProperty(const TraitProperty& p) : CompositeProperty(p), numInitializedAttributes_(0) {}
+
+    virtual ~TraitProperty() override = default;
+
+    /*
+     * Enforce clone method to enable usage as prefab in list property
+     */
+    TraitProperty* clone() const override = 0;
+
+    std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+
+    virtual void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+                              bool useVolumeDataMap) = 0;
+
+    size_t numInitializedAttributes() const { return numInitializedAttributes_; }
+    void inc() { numInitializedAttributes_++; }
+    void reset() { numInitializedAttributes_ = 0; }
+
+private:
+    size_t numInitializedAttributes_;
+};
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/properties/traitproperty.h
@@ -36,9 +36,12 @@ namespace inviwo {
 class IVW_MODULE_FEATURELEVELSETSGL_API TraitProperty : public CompositeProperty {
 public:
     TraitProperty() = delete;
-    TraitProperty(const std::string& identifier, const std::string& displayName)
+    TraitProperty(std::string_view identifier, std::string_view displayName)
         : CompositeProperty(identifier, displayName), numInitializedAttributes_(0) {}
-    TraitProperty(const TraitProperty& p) : CompositeProperty(p), numInitializedAttributes_(0) {}
+    TraitProperty(const TraitProperty& p) = default;
+    TraitProperty(TraitProperty&& p) = default;
+    TraitProperty& operator=(const TraitProperty& p) = delete;
+    TraitProperty& operator=(TraitProperty&& p) = default;
 
     virtual ~TraitProperty() override = default;
 
@@ -47,7 +50,7 @@ public:
     std::string_view getClassIdentifier() const override;
     static constexpr std::string_view classIdentifier{"org.inviwo.TraitProperty"};
 
-    virtual void addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+    virtual void addAttribute(std::string_view name, std::shared_ptr<const Volume> volume,
                               bool useVolumeDataMap) = 0;
 
     size_t numInitializedAttributes() const { return numInitializedAttributes_; }
@@ -55,7 +58,7 @@ public:
     void reset() { numInitializedAttributes_ = 0; }
 
 private:
-    size_t numInitializedAttributes_;
+    size_t numInitializedAttributes_{0};
 };
 
 }  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/util/util.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/util/util.h
@@ -1,0 +1,86 @@
+namespace inviwo {
+namespace util {
+enum class DistanceMetric { Euclidean, Manhattan, Minkowski, SquaredSum };
+
+/**
+ * \brief Calculates Minkowski distance of order n
+ *        Input: Two vectors, each of which represent one point in an
+ * n-dimensional space Output: Minkowski distance of order n between the two
+ * points
+ *
+ * \param a Point a
+ * \param b Point b
+ * \param order Order of the Minkowski distance
+ * \return Minkowski distance of order n between points a and b
+ */
+template <typename T>
+T minkowskiDistance(const std::vector<T>& a, const std::vector<T>& b,
+                    const T order) {
+  IVW_ASSERT(a.size() == b.size(),
+             "Minkowski distance requires equal length vectors");
+  return std::pow(
+      std::inner_product(a.begin(), a.end(), b.begin(), T(0), std::plus<>(),
+                         [order](T x, T y) { return std::pow(y - x, order); }),
+      T(1) / order);
+}
+
+/**
+ * \brief Calculates Manhattan distance
+ *        Input: Two vectors, each of which represent one point in an
+ * n-dimensional space Output: Manhattan distance between the two points
+ *
+ * \param a Point a
+ * \param b Point b
+ * \return Manhattan distance between points a and b
+ */
+template <typename T>
+T manhattanDistance(const std::vector<T>& a, const std::vector<T>& b) {
+  return minkowskiDistance(a, b, T(1));
+}
+
+/**
+ * \brief Calculates Euclidean distance
+ *        Input: Two vectors, each of which represent one point in an
+ * n-dimensional space Output: Euclidean distance between the two points
+ *
+ * \param a Point a
+ * \param b Point b
+ * \return Euclidean distance between points a and b
+ */
+template <typename T>
+T euclideanDistance(const std::vector<T>& a, const std::vector<T>& b) {
+  return minkowskiDistance(a, b, T(2));
+}
+
+/**
+ * \brief Calculates squared sum distance
+ *        Input: Two vectors, each of which represent one point in an
+ * n-dimensional space Output: Squared sum distance between the two points
+ *
+ * \param a Point a
+ * \param b Point b
+ * \return Squared sum distance between points a and b
+ */
+template <typename T>
+T squaredSumDistance(const std::vector<T>& a, const std::vector<T>& b) {
+  IVW_ASSERT(a.size() == b.size(),
+             "Squared sum distance requires equal length vectors");
+  return std::inner_product(a.begin(), a.end(), b.begin(), T(0), std::plus<>(),
+                            [](T x, T y) { return std::pow(y - x, T(2)); });
+}
+
+template <typename T>
+T normalizeValue(const T& val, const T& minVal, const T& maxVal) {
+  if (val >= maxVal) return T(1);
+  if (val <= minVal) return T(0);
+  return (val - minVal) / (maxVal - minVal);
+}
+
+template <typename T>
+T denormalizeValue(const T& val, const T& minVal, const T& maxVal) {
+  if (val <= T(0)) return minVal;
+  if (val >= T(1)) return maxVal;
+  return minVal + val * (maxVal - minVal);
+}
+}  // namespace util
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/util/util.h
+++ b/multivis/featurelevelsetsgl/include/inviwo/featurelevelsetsgl/util/util.h
@@ -14,14 +14,11 @@ enum class DistanceMetric { Euclidean, Manhattan, Minkowski, SquaredSum };
  * \return Minkowski distance of order n between points a and b
  */
 template <typename T>
-T minkowskiDistance(const std::vector<T>& a, const std::vector<T>& b,
-                    const T order) {
-  IVW_ASSERT(a.size() == b.size(),
-             "Minkowski distance requires equal length vectors");
-  return std::pow(
-      std::inner_product(a.begin(), a.end(), b.begin(), T(0), std::plus<>(),
-                         [order](T x, T y) { return std::pow(y - x, order); }),
-      T(1) / order);
+T minkowskiDistance(const std::vector<T>& a, const std::vector<T>& b, const T order) {
+    IVW_ASSERT(a.size() == b.size(), "Minkowski distance requires equal length vectors");
+    return std::pow(std::inner_product(a.begin(), a.end(), b.begin(), T(0), std::plus<>(),
+                                       [order](T x, T y) { return std::pow(y - x, order); }),
+                    T(1) / order);
 }
 
 /**
@@ -35,7 +32,7 @@ T minkowskiDistance(const std::vector<T>& a, const std::vector<T>& b,
  */
 template <typename T>
 T manhattanDistance(const std::vector<T>& a, const std::vector<T>& b) {
-  return minkowskiDistance(a, b, T(1));
+    return minkowskiDistance(a, b, T(1));
 }
 
 /**
@@ -49,7 +46,7 @@ T manhattanDistance(const std::vector<T>& a, const std::vector<T>& b) {
  */
 template <typename T>
 T euclideanDistance(const std::vector<T>& a, const std::vector<T>& b) {
-  return minkowskiDistance(a, b, T(2));
+    return minkowskiDistance(a, b, T(2));
 }
 
 /**
@@ -63,24 +60,23 @@ T euclideanDistance(const std::vector<T>& a, const std::vector<T>& b) {
  */
 template <typename T>
 T squaredSumDistance(const std::vector<T>& a, const std::vector<T>& b) {
-  IVW_ASSERT(a.size() == b.size(),
-             "Squared sum distance requires equal length vectors");
-  return std::inner_product(a.begin(), a.end(), b.begin(), T(0), std::plus<>(),
-                            [](T x, T y) { return std::pow(y - x, T(2)); });
+    IVW_ASSERT(a.size() == b.size(), "Squared sum distance requires equal length vectors");
+    return std::inner_product(a.begin(), a.end(), b.begin(), T(0), std::plus<>(),
+                              [](T x, T y) { return std::pow(y - x, T(2)); });
 }
 
 template <typename T>
 T normalizeValue(const T& val, const T& minVal, const T& maxVal) {
-  if (val >= maxVal) return T(1);
-  if (val <= minVal) return T(0);
-  return (val - minVal) / (maxVal - minVal);
+    if (val >= maxVal) return T(1);
+    if (val <= minVal) return T(0);
+    return (val - minVal) / (maxVal - minVal);
 }
 
 template <typename T>
 T denormalizeValue(const T& val, const T& minVal, const T& maxVal) {
-  if (val <= T(0)) return minVal;
-  if (val >= T(1)) return maxVal;
-  return minVal + val * (maxVal - minVal);
+    if (val <= T(0)) return minVal;
+    if (val >= T(1)) return maxVal;
+    return minVal + val * (maxVal - minVal);
 }
 }  // namespace util
 }  // namespace inviwo

--- a/multivis/featurelevelsetsgl/readme.md
+++ b/multivis/featurelevelsetsgl/readme.md
@@ -1,0 +1,3 @@
+# FeatureLevelSetsGL Module
+
+Description of the FeatureLevelSetsGL module

--- a/multivis/featurelevelsetsgl/src/featurelevelsetsglmodule.cpp
+++ b/multivis/featurelevelsetsgl/src/featurelevelsetsglmodule.cpp
@@ -1,0 +1,49 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/featurelevelsetsgl/featurelevelsetsglmodule.h>
+#include <inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h>
+#include <inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h>
+#include <inviwo/featurelevelsetsgl/properties/pointtraitproperty.h>
+#include <inviwo/featurelevelsetsgl/properties/rangetraitproperty.h>
+#include <modules/opengl/shader/shadermanager.h>
+
+namespace inviwo {
+
+FeatureLevelSetsGLModule::FeatureLevelSetsGLModule(InviwoApplication* app)
+    : InviwoModule(app, "FeatureLevelSetsGL") {
+    ShaderManager::getPtr()->addShaderSearchPath(getPath(ModulePath::GLSL));
+
+    registerProcessor<FeatureLevelSetProcessorGL>();
+    registerProperty<ImplicitFunctionTraitProperty>();
+    registerProperty<PointTraitProperty>();
+    registerProperty<RangeTraitProperty>();
+}
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/featurelevelsetsglmodule.cpp
+++ b/multivis/featurelevelsetsgl/src/featurelevelsetsglmodule.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -50,7 +50,7 @@ namespace inviwo {
 const ProcessorInfo FeatureLevelSetProcessorGL::processorInfo_{
     "org.inviwo.FeatureLevelSetProcessorGL",  // Class identifier
     "Feature Level Sets",                     // Display name
-    "Volume Operation",                          // Category
+    "Volume Operation",                       // Category
     CodeState::Experimental,                  // Code state
     Tags::GL,                                 // Tags
 };
@@ -618,10 +618,9 @@ void FeatureLevelSetProcessorGL::onWillAddProperty(Property* property, size_t) {
             resizeTraitAllocation();
         }
 
-        //traitProperty->onChange([&, this]() { generateTraitMesh(traitProperty->getIdentifier()); });
+        // traitProperty->onChange([&, this]() { generateTraitMesh(traitProperty->getIdentifier());
+        // });
     }
 }
-
-
 
 }  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -31,18 +31,22 @@
 #include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/stringconversion.h>
 #include <inviwo/core/util/zip.h>
-#include <modules/opengl/volume/volumegl.h>
 #include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/network/networklock.h>
+#include <modules/opengl/volume/volumegl.h>
 #include <modules/opengl/texture/textureutils.h>
 #include <modules/opengl/shader/shaderutils.h>
-#include <fmt/format.h>
-#include <inviwo/core/network/networklock.h>
+#include <modules/opengl/texture/textureunit.h>
+#include <modules/opengl/texture/textureutils.h>
+#include <modules/opengl/texture/texture3d.h>
 #include <modules/base/algorithm/dataminmax.h>
-#include <algorithm>
 #include <inviwo/featurelevelsetsgl/util/util.h>
 #include <inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h>
 #include <inviwo/featurelevelsetsgl/properties/pointtraitproperty.h>
 #include <inviwo/featurelevelsetsgl/properties/rangetraitproperty.h>
+
+#include <algorithm>
+#include <fmt/format.h>
 
 namespace inviwo {
 
@@ -55,7 +59,7 @@ const ProcessorInfo FeatureLevelSetProcessorGL::processorInfo_{
     Tags::GL,                                 // Tags
 };
 
-const ProcessorInfo FeatureLevelSetProcessorGL::getProcessorInfo() const { return processorInfo_; }
+const ProcessorInfo& FeatureLevelSetProcessorGL::getProcessorInfo() const { return processorInfo_; }
 
 void FeatureLevelSetProcessorGL::serialize(Serializer& s) const {
     Processor::serialize(s);
@@ -312,7 +316,7 @@ void FeatureLevelSetProcessorGL::process() {
         min = min - max;
     }*/
 
-    outputTexture->dataMap_.valueRange = outputTexture->dataMap_.dataRange =
+    outputTexture->dataMap.valueRange = outputTexture->dataMap.dataRange =
         dvec2(min, capMaxDistance_.get() ? std::min(max, maxDist_) : max);
 
     distanceVolumeOutport_.setData(outputTexture);
@@ -386,7 +390,7 @@ std::vector<vec2> FeatureLevelSetProcessorGL::gatherVolumeRanges() const {
     std::vector<vec2> ranges{};
 
     for (const auto volume : volumes_.getVectorData()) {
-        ranges.emplace_back(volume->dataMap_.dataRange);
+        ranges.emplace_back(volume->dataMap.dataRange);
     }
 
     return ranges;
@@ -505,7 +509,7 @@ void FeatureLevelSetProcessorGL::updateDataRangesCache() {
 
     for (auto&& [index, volume] : util::enumerate(volumes)) {
         if (auto& range = dataRangesCache_[index]; useVolumesDataMap_.get()) {
-            range = volume->dataMap_.valueRange;
+            range = volume->dataMap.valueRange;
         } else {
             auto [mins, maxs] = util::volumeMinMax(volume.get());
             range = dvec2(mins.x, maxs.x);

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -1,0 +1,627 @@
+﻿/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/featurelevelsetsgl/processors/featurelevelsetprocessorgl.h>
+#include <inviwo/core/util/exception.h>
+#include <inviwo/core/util/stringconversion.h>
+#include <inviwo/core/util/zip.h>
+#include <modules/opengl/volume/volumegl.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <modules/opengl/texture/textureutils.h>
+#include <modules/opengl/shader/shaderutils.h>
+#include <fmt/format.h>
+#include <inviwo/core/network/networklock.h>
+#include <modules/base/algorithm/dataminmax.h>
+#include <algorithm>
+#include <inviwo/featurelevelsetsgl/util/util.h>
+#include <inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h>
+#include <inviwo/featurelevelsetsgl/properties/pointtraitproperty.h>
+#include <inviwo/featurelevelsetsgl/properties/rangetraitproperty.h>
+
+namespace inviwo {
+
+// The Class Identifier has to be globally unique. Use a reverse DNS naming scheme
+const ProcessorInfo FeatureLevelSetProcessorGL::processorInfo_{
+    "org.inviwo.FeatureLevelSetProcessorGL",  // Class identifier
+    "Feature Level Sets",                     // Display name
+    "Volume Operation",                          // Category
+    CodeState::Experimental,                  // Code state
+    Tags::GL,                                 // Tags
+};
+
+const ProcessorInfo FeatureLevelSetProcessorGL::getProcessorInfo() const { return processorInfo_; }
+
+void FeatureLevelSetProcessorGL::serialize(Serializer& s) const {
+    Processor::serialize(s);
+    s.serialize("volumeNameCache", volumeNameCache_);
+}
+
+void FeatureLevelSetProcessorGL::deserialize(Deserializer& s) {
+    Processor::deserialize(s);
+    s.deserialize("volumeNameCache", volumeNameCache_);
+}
+
+FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
+    : Processor()
+    , PropertyOwnerObserver()
+    , volumes_("volume")
+    , distanceVolumeOutport_("distanceVolumeOutport")
+    , squaredDistance_("squaredDistance", "Use squared distance", false)
+    , useVolumesDataMap_("useVolumesDataMap", "Use volume's data map", true)
+    , useNormalizedValues_("useNormalizedValues", "Use normalized values", false)
+    , capMaxDistance_("capMaxDistance", "Cap max distance", true)
+    , traitPropertiesContainer_("traitProperties", "Traits")
+    , injectButton_("injectButton", "Inject")
+    , prevNumberOfVolumes_(1)
+    , dataRangesCache_(std::array<vec2, 4>{vec2(0), vec2(0), vec2(0), vec2(0)})
+    , shader_({{
+                  ShaderType::Compute,
+                  "featurelevelsets.comp",
+              }},
+              Shader::Build::No) {
+    traitPropertiesContainer_.addPrefab(
+        std::make_unique<PointTraitProperty>("pointTrait", "Point Trait"));
+    traitPropertiesContainer_.addPrefab(
+        std::make_unique<RangeTraitProperty>("rangeTrait", "Range Trait"));
+    traitPropertiesContainer_.addPrefab(
+        std::make_unique<ImplicitFunctionTraitProperty>("implicitFunction", "Implicit function"));
+
+    addPorts(volumes_, distanceVolumeOutport_);
+    addProperties(squaredDistance_, useVolumesDataMap_, useNormalizedValues_, capMaxDistance_,
+                  traitPropertiesContainer_, injectButton_);
+
+    traitPropertiesContainer_.PropertyOwnerObservable::addObserver(this);
+
+    shader_.onReload([this]() { invalidate(InvalidationLevel::InvalidOutput); });
+    {
+        auto computeShader = shader_.getShaderObject(ShaderType::Compute);
+
+        computeShader->addShaderDefine("NUM_VOLUMES", StrBuffer{"{}", prevNumberOfVolumes_});
+        computeShader->addShaderDefine("TRAIT_ALLOCATION", StrBuffer{"{}", traitAllocation_});
+    }
+    shader_.build();
+
+    squaredDistance_.onChange([this]() {
+        if (auto computeShader = shader_.getShaderObject(ShaderType::Compute);
+            squaredDistance_.get()) {
+            computeShader->addShaderDefine("SQUARED_DISTANCE");
+        } else {
+            computeShader->removeShaderDefine("SQUARED_DISTANCE");
+        }
+
+        shader_.build();
+    });
+
+    volumes_.onConnect([this]() {
+        if (compareInputsToCache()) {
+            return;
+        }
+
+        auto sourceVectorData = volumes_.getSourceVectorData();
+
+        /*
+         * At this point we know that we are not deserializing and that one volume has been
+         * connected. If more that 4 volumes are connected now, just ignore the new volume.
+         * Otherwise, update the attribute properties of all trait properties.
+         */
+        const auto numVolumes = sourceVectorData.size();
+        if (numVolumes > maxVolumes_) {
+            LogWarn(fmt::format("More than {} volumes connected ({}). Ignoring remaining ones.",
+                                maxVolumes_, numVolumes));
+            return;
+        }
+
+        /*
+         * There is a possibility that there are more than 1 newly connected volumes. Therefore,
+         * check if there is only one new volume and then update properties.
+         */
+
+        /*
+         * Return difference sets.
+         */
+        auto [namesToAdd, namesToRemove] = [&inputVolumes = sourceVectorData,
+                                            &volumeNameCache = volumeNameCache_]() {
+            auto sortedCache = std::vector(volumeNameCache);
+            auto inputNames = std::vector<std::string>{};
+            auto namesToAdd = std::vector<std::string>{};
+            auto namesToRemove = std::vector<std::string>{};
+
+            // auto inputVolumes = volumes_.getSourceVectorData();
+            for (const auto& [outport, volume] : inputVolumes) {
+                inputNames.push_back(outport->getProcessor()->getDisplayName());
+            }
+
+            std::sort(std::begin(sortedCache), std::end(sortedCache));
+            std::sort(std::begin(inputNames), std::end(inputNames));
+
+            std::set_difference(std::begin(inputNames), std::end(inputNames),
+                                std::begin(sortedCache), std::end(sortedCache),
+                                std::back_inserter(namesToAdd));
+
+            std::set_difference(std::begin(sortedCache), std::end(sortedCache),
+                                std::begin(inputNames), std::end(inputNames),
+                                std::back_inserter(namesToRemove));
+
+            return std::pair(namesToAdd, namesToRemove);
+        }();
+
+        /*
+         * This is not production code, for now just handle case of +1, otherwise reset everything.
+         */
+        if (!namesToRemove.empty() || namesToAdd.size() != 1) {
+            initializeAllProperties();
+            return;
+        }
+
+        /*
+         * Find volume with corresponding name
+         */
+        const auto pair =
+            std::find_if(std::begin(sourceVectorData), std::end(sourceVectorData),
+                         [&name = namesToAdd.front()](const auto& pair) {
+                             return pair.first->getProcessor()->getDisplayName() == name;
+                         });
+
+        const auto& [outport, volume] = *pair;
+
+        for (const auto property : traitPropertiesContainer_.getProperties()) {
+            if (auto traitProperty = dynamic_cast<TraitProperty*>(property)) {
+
+                traitProperty->addAttribute(outport->getProcessor()->getDisplayName(), volume,
+                                            useVolumesDataMap_.get());
+
+                traitProperty->setSerializationMode(PropertySerializationMode::All);
+            }
+        }
+
+        updateNormalizedVolumesCache();
+    });
+
+    volumes_.onChange([this]() {
+        updateVolumeNamesCache();
+
+        auto computeShader = shader_.getShaderObject(ShaderType::Compute);
+
+        computeShader->removeShaderDefine(StrBuffer{"NUM_VOLUMES {}", prevNumberOfVolumes_});
+
+        prevNumberOfVolumes_ = volumes_.getVectorData().size();
+
+        computeShader->addShaderDefine("NUM_VOLUMES", StrBuffer{"{}", prevNumberOfVolumes_});
+
+        checkInput();
+
+        shader_.build();
+
+        updateDataRangesCache();
+
+        updateNormalizedVolumesCache();
+
+        updateMaximumDistance();
+    });
+
+    volumes_.onDisconnect([this]() {
+        const auto sourceVectorData = volumes_.getSourceVectorData();
+
+        if (const auto numVolumes = sourceVectorData.size(); numVolumes > maxVolumes_) {
+            LogWarn(fmt::format("More than {} volumes connected ({}). Ignoring remaining ones.",
+                                maxVolumes_, numVolumes));
+            return;
+        }
+        /*
+         * Return difference sets.
+         */
+        auto [namesToAdd, namesToRemove] = [inputVolumes = volumes_.getSourceVectorData(),
+                                            &volumeNameCache = volumeNameCache_]() {
+            auto sortedCache = std::vector(volumeNameCache);
+            auto inputNames = std::vector<std::string>{};
+            auto namesToAdd = std::vector<std::string>{};
+            auto namesToRemove = std::vector<std::string>{};
+
+            // auto inputVolumes = volumes_.getSourceVectorData();
+            for (const auto& [outport, volume] : inputVolumes) {
+                inputNames.push_back(outport->getProcessor()->getDisplayName());
+            }
+
+            std::sort(std::begin(sortedCache), std::end(sortedCache));
+            std::sort(std::begin(inputNames), std::end(inputNames));
+
+            std::set_difference(std::begin(inputNames), std::end(inputNames),
+                                std::begin(sortedCache), std::end(sortedCache),
+                                std::back_inserter(namesToAdd));
+
+            std::set_difference(std::begin(sortedCache), std::end(sortedCache),
+                                std::begin(inputNames), std::end(inputNames),
+                                std::back_inserter(namesToRemove));
+
+            return std::pair(namesToAdd, namesToRemove);
+        }();
+
+        /*
+         * For now, reset everything, research must go on.
+         */
+        initializeAllProperties();
+
+        updateNormalizedVolumesCache();
+    });
+
+    injectButton_.onChange([this]() {
+        for (auto property : traitPropertiesContainer_.getProperties()) {
+            if (auto implicitFunctionTraitProperty =
+                    dynamic_cast<ImplicitFunctionTraitProperty*>(property)) {
+                implicitFunctionTraitProperty->inject(shader_);
+            }
+        }
+    });
+
+    capMaxDistance_.onChange([this]() {
+        if (capMaxDistance_.get()) {
+            LogInfoCustom("Feature Level Sets",
+                          fmt::format("Capping max distance at {}.", maxDist_));
+        } else {
+            LogInfoCustom("Feature Level Sets", "Capping disabled.");
+        }
+    });
+}
+
+void FeatureLevelSetProcessorGL::process() {
+    if (!volumes_.hasData() || volumes_.getVectorData().empty()) return;
+    if (traitPropertiesContainer_.getProperties().empty()) return;
+
+    checkInput();
+
+    shader_.activate();
+
+    setUniforms();
+
+    const auto outputTexture = bindOutputTexture();
+
+    gpuDispatch();
+
+    shader_.deactivate();
+
+    auto min = reduction_.reduce_v(outputTexture, ReductionOperator::Min);
+    const auto max = reduction_.reduce_v(outputTexture, ReductionOperator::Max);
+
+    /*if (std::abs(max - min) < std::numeric_limits<double>::epsilon()) {
+        min = min - max;
+    }*/
+
+    outputTexture->dataMap_.valueRange = outputTexture->dataMap_.dataRange =
+        dvec2(min, capMaxDistance_.get() ? std::min(max, maxDist_) : max);
+
+    distanceVolumeOutport_.setData(outputTexture);
+}
+
+void FeatureLevelSetProcessorGL::checkInput() const {
+    const size3_t dims = volumes_.getData()->getDimensions();
+    for (const auto vol : volumes_) {
+        if (dims != vol->getDimensions()) {
+            throw Exception(fmt::format("Different volume dimensions: {}, expected {}",
+                                        glm::to_string(vol->getDimensions()), glm::to_string(dims)),
+                            IVW_CONTEXT);
+        }
+
+        if (vol->getDataFormat()->getNumericType() != NumericType::Float) {
+            LogWarn("Sampling non-float volume, shader will normalize values.");
+        }
+    }
+}
+
+std::vector<vec4> FeatureLevelSetProcessorGL::gatherPointTraits() const {
+    auto properties = traitPropertiesContainer_.getProperties();
+    std::vector<vec4> pointTraits;
+
+    for (auto property : properties) {
+        if (const auto pointTraitProperty = dynamic_cast<PointTraitProperty*>(property)) {
+            pointTraits.push_back(pointTraitProperty->getAsVec4());
+        }
+    }
+
+    return pointTraits;
+}
+
+void FeatureLevelSetProcessorGL::normalizePointTraits(std::vector<vec4>& pointTraits) const {
+    for (auto& pointTrait : pointTraits) {
+        for (size_t i{0}; i < 4; i++) {
+            pointTrait[i] =
+                util::normalizeValue(pointTrait[i], dataRangesCache_[i].x, dataRangesCache_[i].y);
+        }
+    }
+}
+
+std::vector<mat4> FeatureLevelSetProcessorGL::gatherRangeTraits() const {
+    auto properties = traitPropertiesContainer_.getProperties();
+    std::vector<mat4> rangeTraits{};
+
+    for (auto property : properties) {
+        if (const auto rangeTraitProperty = dynamic_cast<RangeTraitProperty*>(property)) {
+            rangeTraits.push_back(rangeTraitProperty->getAsMat4());
+        }
+    }
+
+    return rangeTraits;
+}
+
+void FeatureLevelSetProcessorGL::normalizeRangeTraits(std::vector<mat4>& rangeTraits) const {
+    for (auto& rangeTrait : rangeTraits) {
+        for (size_t i{0}; i < 4; i++) {
+            auto minVal = rangeTrait[i][0];
+            auto maxVal = rangeTrait[i][1];
+
+            rangeTrait[i][0] =
+                util::normalizeValue(minVal, dataRangesCache_[i].x, dataRangesCache_[i].y);
+            rangeTrait[i][1] =
+                util::normalizeValue(maxVal, dataRangesCache_[i].x, dataRangesCache_[i].y);
+        }
+    }
+}
+
+std::vector<vec2> FeatureLevelSetProcessorGL::gatherVolumeRanges() const {
+    std::vector<vec2> ranges{};
+
+    for (const auto volume : volumes_.getVectorData()) {
+        ranges.emplace_back(volume->dataMap_.dataRange);
+    }
+
+    return ranges;
+}
+
+void FeatureLevelSetProcessorGL::normalizeVolumeRanges(std::vector<vec2>& volumeRanges) const {
+    std::transform(std::begin(volumeRanges), std::end(volumeRanges), std::begin(volumeRanges),
+                   [](const auto&) {
+                       return vec2{0.f, 1.f};
+                   });
+}
+
+void FeatureLevelSetProcessorGL::setUniforms() {
+    const size3_t dims = volumes_.getData()->getDimensions();
+
+    TextureUnitContainer cont;
+
+    if (!useNormalizedValues_.get()) {
+        size_t idx{0};
+
+        for (auto& [outport, volume] : volumes_.getSourceVectorData()) {
+            if (idx >= maxVolumes_) break;
+            LogInfo("Binding " + outport->getProcessor()->getDisplayName() + " at index " +
+                    std::to_string(idx));
+            TextureUnit unit;
+            utilgl::bindTexture(*volume, unit);
+            shader_.setUniform(StrBuffer{"volume[{}]", idx}, unit.getUnitNumber());
+            utilgl::setShaderUniforms(shader_, *volume, StrBuffer{"volumeParameters[{}]", idx++});
+            cont.push_back(std::move(unit));
+        }
+    } else {
+        for (auto&& [index, volume] : util::enumerate(normalizedVolumesCache_)) {
+            if (index >= maxVolumes_) break;
+            LogInfo("Binding " + volume.first + " at index " + std::to_string(index));
+            auto vol = volume.second;
+            TextureUnit unit;
+            utilgl::bindTexture(*vol, unit);
+            shader_.setUniform(StrBuffer{"volume[{}]", index}, unit.getUnitNumber());
+            utilgl::setShaderUniforms(shader_, *vol, StrBuffer{"volumeParameters[{}]", index});
+            cont.push_back(std::move(unit));
+        }
+    }
+
+    LogInfo("--------------------------------------");
+
+    shader_.setUniform("dest", 0);
+
+    auto pointTraits = gatherPointTraits();
+    auto rangeTraits = gatherRangeTraits();
+    auto volumeRanges = gatherVolumeRanges();
+
+    if (useNormalizedValues_.get()) {
+        normalizePointTraits(pointTraits);
+        normalizeRangeTraits(rangeTraits);
+        normalizeVolumeRanges(volumeRanges);
+    }
+
+    shader_.setUniform("pointTraits", pointTraits);
+    shader_.setUniform("rangeTraits", rangeTraits);
+    shader_.setUniform("volumeRanges", volumeRanges);
+
+    shader_.setUniform("numPointTraits", static_cast<int>(pointTraits.size()));
+    shader_.setUniform("numRangeTraits", static_cast<int>(rangeTraits.size()));
+}
+
+std::shared_ptr<Volume> FeatureLevelSetProcessorGL::bindOutputTexture() {
+    auto inputVolumes = volumes_.getVectorData();
+    const size3_t dims = inputVolumes.front()->getDimensions();
+    auto referenceBasis = inputVolumes.front()->getBasis();
+    auto referenceOffset = inputVolumes.front()->getOffset();
+
+    for (auto volume : inputVolumes) {
+        if (glm::any(glm::notEqual(referenceBasis, volume->getBasis()))) {
+            LogWarn(
+                "Input volumes do not have the same bases. Setting basis of input volume 1 for the "
+                "output volume.");
+        }
+        if (glm::any(glm::notEqual(referenceOffset, volume->getOffset()))) {
+            LogWarn(
+                "Input volumes do not have the same offsets. Setting offset of input volume 1 for "
+                "the output volume.");
+        }
+    }
+
+    auto distanceVolume = std::make_shared<Volume>(dims, DataFloat32::get());
+    distanceVolume->setBasis(inputVolumes.front()->getBasis());
+    distanceVolume->setOffset(inputVolumes.front()->getOffset());
+    auto distanceVolumeGL = distanceVolume->getEditableRepresentation<VolumeGL>();
+
+    glActiveTexture(GL_TEXTURE0);
+
+    auto texHandle = distanceVolumeGL->getTexture()->getID();
+    glBindImageTexture(0, texHandle, 0, GL_FALSE, 0, GL_WRITE_ONLY, GL_R32F);
+
+    distanceVolumeGL->setSwizzleMask(swizzlemasks::rgba);
+
+    distanceVolumeGL->getTexture()->bind();
+
+    return distanceVolume;
+}
+
+void FeatureLevelSetProcessorGL::gpuDispatch() {
+    const size3_t dims = volumes_.getData()->getDimensions();
+
+    const auto x = static_cast<GLuint>(dims.x);
+    const auto y = static_cast<GLuint>(dims.y);
+    const auto z = static_cast<GLuint>(dims.z);
+
+    glDispatchCompute(x, y, z);
+
+    glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+}
+
+void FeatureLevelSetProcessorGL::updateDataRangesCache() {
+    auto volumes = volumes_.getVectorData();
+
+    for (auto&& [index, volume] : util::enumerate(volumes)) {
+        if (auto& range = dataRangesCache_[index]; useVolumesDataMap_.get()) {
+            range = volume->dataMap_.valueRange;
+        } else {
+            auto [mins, maxs] = util::volumeMinMax(volume.get());
+            range = dvec2(mins.x, maxs.x);
+        }
+    }
+}
+
+void FeatureLevelSetProcessorGL::updateMaximumDistance() {
+    auto volumes = volumes_.getVectorData();
+
+    if (useNormalizedValues_.get()) {
+        maxDist_ = std::sqrt(volumes.size());
+        return;
+    }
+
+    std::vector<double> minVec{};
+    std::vector<double> maxVec{};
+
+    for (auto range : dataRangesCache_) {
+        minVec.push_back(range.x);
+        maxVec.push_back(range.y);
+    }
+
+    maxDist_ = util::euclideanDistance(minVec, maxVec);
+}
+
+void FeatureLevelSetProcessorGL::updateNormalizedVolumesCache() {
+    normalizedVolumesCache_.clear();
+    for (auto& [outport, volume] : volumes_.getSourceVectorData()) {
+        normalizedVolumesCache_.emplace_back(outport->getProcessor()->getDisplayName(),
+                                             normalization_.normalize(*volume));
+    }
+}
+
+bool FeatureLevelSetProcessorGL::compareInputsToCache() const {
+    std::vector<std::string> names{};
+    std::vector<std::string> intersection{};
+    std::vector<std::string> nameCache(volumeNameCache_);
+
+    for (auto [outport, volume] : volumes_.getSourceVectorData()) {
+        names.push_back(outport->getProcessor()->getDisplayName());
+    }
+
+    std::sort(std::begin(names), std::end(names));
+    std::sort(std::begin(nameCache), std::end(nameCache));
+
+    std::set_intersection(std::begin(names), std::end(names), std::begin(nameCache),
+                          std::end(nameCache), std::back_inserter(intersection));
+
+    const auto matchesAll = nameCache.size() == intersection.size();
+    const auto sameAmount = names.size() == nameCache.size();
+
+    return matchesAll && sameAmount;
+}
+
+void FeatureLevelSetProcessorGL::updateVolumeNamesCache() {
+    auto volumes = volumes_.getSourceVectorData();
+
+    std::vector<std::string> names{};
+
+    names.reserve(volumes.size());
+
+    for (const auto& [outport, volume] : volumes) {
+        names.push_back(outport->getProcessor()->getDisplayName());
+    }
+
+    volumeNameCache_ = names;
+}
+
+void FeatureLevelSetProcessorGL::resizeTraitAllocation() {
+    auto computeShader = shader_.getShaderObject(ShaderType::Compute);
+
+    computeShader->removeShaderDefine(StrBuffer{"TRAIT_ALLOCATION {}", traitAllocation_});
+
+    traitAllocation_ += 8;
+
+    computeShader->addShaderDefine("TRAIT_ALLOCATION", StrBuffer{"{}", traitAllocation_});
+
+    shader_.build();
+}
+
+void FeatureLevelSetProcessorGL::initializeAllProperties() {
+    for (auto property : traitPropertiesContainer_.getProperties()) {
+        auto traitProperty = dynamic_cast<TraitProperty*>(property);
+        traitProperty->reset();
+        for (const auto [outport, volume] : volumes_.getSourceVectorData()) {
+            traitProperty->addAttribute(outport->getProcessor()->getDisplayName(), volume,
+                                        useVolumesDataMap_.get());
+        }
+    }
+}
+
+void FeatureLevelSetProcessorGL::onWillAddProperty(Property* property, size_t) {
+    if (!volumes_.isConnected()) {
+        return;
+    }
+
+    const auto volumes = volumes_.getSourceVectorData();
+
+    if (auto traitProperty = dynamic_cast<TraitProperty*>(property)) {
+
+        for (const auto& [outport, volume] : volumes) {
+            traitProperty->addAttribute(outport->getProcessor()->getDisplayName(), volume,
+                                        useVolumesDataMap_.get());
+        }
+
+        traitProperty->setSerializationMode(PropertySerializationMode::All);
+
+        if (traitPropertiesContainer_.getProperties().size() > traitAllocation_) {
+            resizeTraitAllocation();
+        }
+
+        //traitProperty->onChange([&, this]() { generateTraitMesh(traitProperty->getIdentifier()); });
+    }
+}
+
+
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -207,28 +207,6 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
         updateNormalizedVolumesCache();
     });
 
-    volumes_.onChange([this]() {
-        updateVolumeNamesCache();
-
-        auto computeShader = shader_.getShaderObject(ShaderType::Compute);
-
-        computeShader->removeShaderDefine(StrBuffer{"NUM_VOLUMES {}", prevNumberOfVolumes_});
-
-        prevNumberOfVolumes_ = volumes_.getVectorData().size();
-
-        computeShader->addShaderDefine("NUM_VOLUMES", StrBuffer{"{}", prevNumberOfVolumes_});
-
-        checkInput();
-
-        shader_.build();
-
-        updateDataRangesCache();
-
-        updateNormalizedVolumesCache();
-
-        updateMaximumDistance();
-    });
-
     volumes_.onDisconnect([this]() {
         const auto sourceVectorData = volumes_.getSourceVectorData();
 
@@ -293,6 +271,23 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
 }
 
 void FeatureLevelSetProcessorGL::process() {
+    if (volumes_.isChanged()) {
+        updateVolumeNamesCache();
+
+        auto computeShader = shader_.getShaderObject(ShaderType::Compute);
+
+        computeShader->removeShaderDefine(StrBuffer{"NUM_VOLUMES {}", prevNumberOfVolumes_});
+        prevNumberOfVolumes_ = volumes_.getVectorData().size();
+        computeShader->addShaderDefine("NUM_VOLUMES", StrBuffer{"{}", prevNumberOfVolumes_});
+
+        checkInput();
+
+        shader_.build();
+        updateDataRangesCache();
+        updateNormalizedVolumesCache();
+        updateMaximumDistance();
+    }
+
     if (!volumes_.hasData() || volumes_.getVectorData().empty()) return;
     if (traitPropertiesContainer_.getProperties().empty()) return;
 

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -152,9 +152,9 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
         auto [namesToAdd, namesToRemove] = [&inputVolumes = sourceVectorData,
                                             &volumeNameCache = volumeNameCache_]() {
             auto sortedCache = std::vector(volumeNameCache);
-            auto inputNames = std::vector<std::string>{};
-            auto namesToAdd = std::vector<std::string>{};
-            auto namesToRemove = std::vector<std::string>{};
+            auto inputNames = std::vector<std::string_view>{};
+            auto namesToAdd = std::vector<std::string_view>{};
+            auto namesToRemove = std::vector<std::string_view>{};
 
             // auto inputVolumes = volumes_.getSourceVectorData();
             for (const auto& [outport, volume] : inputVolumes) {
@@ -243,9 +243,9 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
         auto [namesToAdd, namesToRemove] = [inputVolumes = volumes_.getSourceVectorData(),
                                             &volumeNameCache = volumeNameCache_]() {
             auto sortedCache = std::vector(volumeNameCache);
-            auto inputNames = std::vector<std::string>{};
-            auto namesToAdd = std::vector<std::string>{};
-            auto namesToRemove = std::vector<std::string>{};
+            auto inputNames = std::vector<std::string_view>{};
+            auto namesToAdd = std::vector<std::string_view>{};
+            auto namesToRemove = std::vector<std::string_view>{};
 
             // auto inputVolumes = volumes_.getSourceVectorData();
             for (const auto& [outport, volume] : inputVolumes) {
@@ -540,19 +540,18 @@ void FeatureLevelSetProcessorGL::updateNormalizedVolumesCache() {
 }
 
 bool FeatureLevelSetProcessorGL::compareInputsToCache() const {
-    std::vector<std::string> names{};
-    std::vector<std::string> intersection{};
+    std::vector<std::string_view> names{};
+    std::vector<std::string_view> intersection{};
     std::vector<std::string> nameCache(volumeNameCache_);
 
     for (auto [outport, volume] : volumes_.getSourceVectorData()) {
         names.push_back(outport->getProcessor()->getDisplayName());
     }
 
-    std::sort(std::begin(names), std::end(names));
-    std::sort(std::begin(nameCache), std::end(nameCache));
+    std::ranges::sort(names);
+    std::ranges::sort(nameCache);
 
-    std::set_intersection(std::begin(names), std::end(names), std::begin(nameCache),
-                          std::end(nameCache), std::back_inserter(intersection));
+    std::ranges::set_intersection(names, nameCache, std::back_inserter(intersection));
 
     const auto matchesAll = nameCache.size() == intersection.size();
     const auto sameAmount = names.size() == nameCache.size();
@@ -563,15 +562,12 @@ bool FeatureLevelSetProcessorGL::compareInputsToCache() const {
 void FeatureLevelSetProcessorGL::updateVolumeNamesCache() {
     auto volumes = volumes_.getSourceVectorData();
 
-    std::vector<std::string> names{};
-
-    names.reserve(volumes.size());
+    volumeNameCache_.clear();
+    volumeNameCache_.reserve(volumes.size());
 
     for (const auto& [outport, volume] : volumes) {
-        names.push_back(outport->getProcessor()->getDisplayName());
+        volumeNameCache_.push_back(std::string{outport->getProcessor()->getDisplayName()});
     }
-
-    volumeNameCache_ = names;
 }
 
 void FeatureLevelSetProcessorGL::resizeTraitAllocation() {

--- a/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
+++ b/multivis/featurelevelsetsgl/src/processors/featurelevelsetprocessorgl.cpp
@@ -136,8 +136,8 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
          */
         const auto numVolumes = sourceVectorData.size();
         if (numVolumes > maxVolumes_) {
-            LogWarn(fmt::format("More than {} volumes connected ({}). Ignoring remaining ones.",
-                                maxVolumes_, numVolumes));
+            log::warn("More than {} volumes connected ({}). Ignoring remaining ones.", maxVolumes_,
+                      numVolumes);
             return;
         }
 
@@ -233,8 +233,8 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
         const auto sourceVectorData = volumes_.getSourceVectorData();
 
         if (const auto numVolumes = sourceVectorData.size(); numVolumes > maxVolumes_) {
-            LogWarn(fmt::format("More than {} volumes connected ({}). Ignoring remaining ones.",
-                                maxVolumes_, numVolumes));
+            log::warn("More than {} volumes connected ({}). Ignoring remaining ones.", maxVolumes_,
+                      numVolumes);
             return;
         }
         /*
@@ -285,10 +285,9 @@ FeatureLevelSetProcessorGL::FeatureLevelSetProcessorGL()
 
     capMaxDistance_.onChange([this]() {
         if (capMaxDistance_.get()) {
-            LogInfoCustom("Feature Level Sets",
-                          fmt::format("Capping max distance at {}.", maxDist_));
+            log::info("Capping max distance at {}.", maxDist_);
         } else {
-            LogInfoCustom("Feature Level Sets", "Capping disabled.");
+            log::info("Capping disabled.");
         }
     });
 }
@@ -326,13 +325,12 @@ void FeatureLevelSetProcessorGL::checkInput() const {
     const size3_t dims = volumes_.getData()->getDimensions();
     for (const auto vol : volumes_) {
         if (dims != vol->getDimensions()) {
-            throw Exception(fmt::format("Different volume dimensions: {}, expected {}",
-                                        glm::to_string(vol->getDimensions()), glm::to_string(dims)),
-                            IVW_CONTEXT);
+            throw Exception(SourceContext{}, "Different volume dimensions: {}, expected {}",
+                            glm::to_string(vol->getDimensions()), glm::to_string(dims));
         }
 
         if (vol->getDataFormat()->getNumericType() != NumericType::Float) {
-            LogWarn("Sampling non-float volume, shader will normalize values.");
+            log::warn("Sampling non-float volume, shader will normalize values.");
         }
     }
 }
@@ -398,9 +396,7 @@ std::vector<vec2> FeatureLevelSetProcessorGL::gatherVolumeRanges() const {
 
 void FeatureLevelSetProcessorGL::normalizeVolumeRanges(std::vector<vec2>& volumeRanges) const {
     std::transform(std::begin(volumeRanges), std::end(volumeRanges), std::begin(volumeRanges),
-                   [](const auto&) {
-                       return vec2{0.f, 1.f};
-                   });
+                   [](const auto&) { return vec2{0.f, 1.f}; });
 }
 
 void FeatureLevelSetProcessorGL::setUniforms() {
@@ -413,8 +409,7 @@ void FeatureLevelSetProcessorGL::setUniforms() {
 
         for (auto& [outport, volume] : volumes_.getSourceVectorData()) {
             if (idx >= maxVolumes_) break;
-            LogInfo("Binding " + outport->getProcessor()->getDisplayName() + " at index " +
-                    std::to_string(idx));
+            log::info("Binding {} at index {}", outport->getProcessor()->getDisplayName(), idx);
             TextureUnit unit;
             utilgl::bindTexture(*volume, unit);
             shader_.setUniform(StrBuffer{"volume[{}]", idx}, unit.getUnitNumber());
@@ -424,7 +419,7 @@ void FeatureLevelSetProcessorGL::setUniforms() {
     } else {
         for (auto&& [index, volume] : util::enumerate(normalizedVolumesCache_)) {
             if (index >= maxVolumes_) break;
-            LogInfo("Binding " + volume.first + " at index " + std::to_string(index));
+            log::info("Binding {} at index {}", volume.first, index);
             auto vol = volume.second;
             TextureUnit unit;
             utilgl::bindTexture(*vol, unit);
@@ -434,7 +429,7 @@ void FeatureLevelSetProcessorGL::setUniforms() {
         }
     }
 
-    LogInfo("--------------------------------------");
+    log::info("--------------------------------------");
 
     shader_.setUniform("dest", 0);
 
@@ -464,12 +459,12 @@ std::shared_ptr<Volume> FeatureLevelSetProcessorGL::bindOutputTexture() {
 
     for (auto volume : inputVolumes) {
         if (glm::any(glm::notEqual(referenceBasis, volume->getBasis()))) {
-            LogWarn(
+            log::warn(
                 "Input volumes do not have the same bases. Setting basis of input volume 1 for the "
                 "output volume.");
         }
         if (glm::any(glm::notEqual(referenceOffset, volume->getOffset()))) {
-            LogWarn(
+            log::warn(
                 "Input volumes do not have the same offsets. Setting offset of input volume 1 for "
                 "the output volume.");
         }

--- a/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
@@ -1,48 +1,62 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
 #include <inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h>
 #include <inviwo/core/util/stringconversion.h>
+#include <modules/opengl/shader/shader.h>
+
+#include <fmt/base.h>
 
 namespace inviwo {
-const std::string ImplicitFunctionTraitProperty::classIdentifier =
-    "org.inviwo.ImplicitFunctionTraitProperty";
-std::string ImplicitFunctionTraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+std::string_view ImplicitFunctionTraitProperty::getClassIdentifier() const {
+    return classIdentifier;
+}
 
 void ImplicitFunctionTraitProperty::addAttribute(const std::string&, std::shared_ptr<const Volume>,
                                                  bool) {}
 
-void ImplicitFunctionTraitProperty::inject(Shader& shader) {
+void ImplicitFunctionTraitProperty::inject(Shader& shader) const {
     const auto identifier = getIdentifier();
     const auto itIdentifier = std::find_if(identifier.rbegin(), identifier.rend(),
                                            [](char c) { return !std::isdigit(c); });
-    std::string number(itIdentifier.base(), identifier.end());
-    if (number.empty()) number = "1";
-
-    if (originalShader_.empty()) {
-        originalShader_ = shader.getComputeShaderObject()->getResource()->source();
+    std::string_view number(itIdentifier.base(), identifier.end());
+    if (number.empty()) {
+        number = "1";
     }
 
-    auto content = originalShader_;
+    auto* computeShader = shader.getComputeShaderObject();
 
-    replaceInString(content, "// #define ENABLE_IMPLICIT_FUNCTION_" + number,
-                    "#define ENABLE_IMPLICIT_FUNCTION_" + number);
-
-    auto functionCode = shaderInjection_.get();
-    replaceInString(functionCode, "\n", "\n    ");
-
-    replaceInString(content, "// #IMPLICIT_FUNCTION_" + number, functionCode);
-
-    auto shaderResource =
-        std::make_shared<StringShaderResource>("featurelevelsets" + number + ".comp", content);
-
-    Shader newShader{{{
-                         ShaderType::Compute,
-                         shaderResource,
-                     }},
-                     Shader::Build::No};
-    newShader.getComputeShaderObject()->setShaderDefines(
-        shader.getComputeShaderObject()->getShaderDefines());
-
-    shader = newShader;
-
+    StrBuffer buf;
+    computeShader->addShaderDefine(buf.replace("ENABLE_IMPLICIT_FUNCTION_{}", number));
+    computeShader->addShaderDefine(buf.replace("IMPLICIT_FUNCTION_{}", number),
+                                   shaderInjection_.get());
     shader.build();
 }
 

--- a/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
@@ -1,0 +1,49 @@
+#include <inviwo/featurelevelsetsgl/properties/implicitfunctiontraitproperty.h>
+#include <inviwo/core/util/stringconversion.h>
+
+namespace inviwo {
+const std::string ImplicitFunctionTraitProperty::classIdentifier =
+    "org.inviwo.ImplicitFunctionTraitProperty";
+std::string ImplicitFunctionTraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+void ImplicitFunctionTraitProperty::addAttribute(const std::string&, std::shared_ptr<const Volume>,
+                                                 bool) {}
+
+void ImplicitFunctionTraitProperty::inject(Shader& shader) {
+    const auto identifier = getIdentifier();
+    const auto itIdentifier = std::find_if(identifier.rbegin(), identifier.rend(),
+                                           [](char c) { return !std::isdigit(c); });
+    std::string number(itIdentifier.base(), identifier.end());
+    if (number.empty()) number = "1";
+
+    if (originalShader_.empty()) {
+        originalShader_ = shader.getComputeShaderObject()->getResource()->source();
+    }
+
+    auto content = originalShader_;
+
+    replaceInString(content, "// #define ENABLE_IMPLICIT_FUNCTION_" + number,
+                    "#define ENABLE_IMPLICIT_FUNCTION_" + number);
+
+    auto functionCode = shaderInjection_.get();
+    replaceInString(functionCode, "\n", "\n    ");
+
+    replaceInString(content, "// #IMPLICIT_FUNCTION_" + number, functionCode);
+
+    auto shaderResource =
+        std::make_shared<StringShaderResource>("featurelevelsets" + number + ".comp", content);
+
+    Shader newShader{{{
+                         ShaderType::Compute,
+                         shaderResource,
+                     }},
+                     Shader::Build::No};
+    newShader.getComputeShaderObject()->setShaderDefines(
+        shader.getComputeShaderObject()->getShaderDefines());
+
+    shader = newShader;
+
+    shader.build();
+}
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/implicitfunctiontraitproperty.cpp
@@ -39,7 +39,7 @@ std::string_view ImplicitFunctionTraitProperty::getClassIdentifier() const {
     return classIdentifier;
 }
 
-void ImplicitFunctionTraitProperty::addAttribute(const std::string&, std::shared_ptr<const Volume>,
+void ImplicitFunctionTraitProperty::addAttribute(std::string_view, std::shared_ptr<const Volume>,
                                                  bool) {}
 
 void ImplicitFunctionTraitProperty::inject(Shader& shader) const {

--- a/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
@@ -1,0 +1,29 @@
+#include <inviwo/featurelevelsetsgl/properties/pointtraitproperty.h>
+#include <modules/base/algorithm/dataminmax.h>
+
+namespace inviwo {
+const std::string PointTraitProperty::classIdentifier = "org.inviwo.PointTraitProperty";
+std::string PointTraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+vec4 PointTraitProperty::getAsVec4() const {
+    return vec4(attribute1_.get(), attribute2_.get(), attribute3_.get(), attribute4_.get());
+}
+
+void PointTraitProperty::addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+                                      bool useVolumeDataMap) {
+    const auto minVal = useVolumeDataMap
+                            ? vec2(volume->dataMap_.valueRange).x
+                            : static_cast<float>(util::volumeMinMax(volume.get()).first.x);
+    const auto maxVal = useVolumeDataMap
+                            ? vec2(volume->dataMap_.valueRange).y
+                            : static_cast<float>(util::volumeMinMax(volume.get()).second.x);
+
+    attributes_[numInitializedAttributes()]->setVisible(true);
+    attributes_[numInitializedAttributes()]->set(minVal);
+    attributes_[numInitializedAttributes()]->setMinValue(minVal);
+    attributes_[numInitializedAttributes()]->setMaxValue(maxVal);
+    attributes_[numInitializedAttributes()]->setDisplayName(name);
+
+    inc();
+}
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
@@ -1,9 +1,38 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
 #include <inviwo/featurelevelsetsgl/properties/pointtraitproperty.h>
 #include <modules/base/algorithm/dataminmax.h>
 
 namespace inviwo {
-const std::string PointTraitProperty::classIdentifier = "org.inviwo.PointTraitProperty";
-std::string PointTraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+std::string_view PointTraitProperty::getClassIdentifier() const { return classIdentifier; }
 
 vec4 PointTraitProperty::getAsVec4() const {
     return vec4(attribute1_.get(), attribute2_.get(), attribute3_.get(), attribute4_.get());
@@ -12,10 +41,10 @@ vec4 PointTraitProperty::getAsVec4() const {
 void PointTraitProperty::addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
                                       bool useVolumeDataMap) {
     const auto minVal = useVolumeDataMap
-                            ? vec2(volume->dataMap_.valueRange).x
+                            ? vec2(volume->dataMap.valueRange).x
                             : static_cast<float>(util::volumeMinMax(volume.get()).first.x);
     const auto maxVal = useVolumeDataMap
-                            ? vec2(volume->dataMap_.valueRange).y
+                            ? vec2(volume->dataMap.valueRange).y
                             : static_cast<float>(util::volumeMinMax(volume.get()).second.x);
 
     attributes_[numInitializedAttributes()]->setVisible(true);
@@ -26,4 +55,5 @@ void PointTraitProperty::addAttribute(const std::string& name, std::shared_ptr<c
 
     inc();
 }
+
 }  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/pointtraitproperty.cpp
@@ -38,7 +38,7 @@ vec4 PointTraitProperty::getAsVec4() const {
     return vec4(attribute1_.get(), attribute2_.get(), attribute3_.get(), attribute4_.get());
 }
 
-void PointTraitProperty::addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+void PointTraitProperty::addAttribute(std::string_view name, std::shared_ptr<const Volume> volume,
                                       bool useVolumeDataMap) {
     const auto minVal = useVolumeDataMap
                             ? vec2(volume->dataMap.valueRange).x

--- a/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
@@ -1,0 +1,43 @@
+#include <inviwo/featurelevelsetsgl/properties/rangetraitproperty.h>
+#include <modules/base/algorithm/dataminmax.h>
+
+namespace inviwo {
+const std::string RangeTraitProperty::classIdentifier = "org.inviwo.RangeTraitProperty";
+std::string RangeTraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+mat4 RangeTraitProperty::getAsMat4() const {
+    mat4 minMaxes;
+
+    minMaxes[0][0] = attributes_[0]->get().r;
+    minMaxes[0][1] = attributes_[0]->get().g;
+
+    minMaxes[1][0] = attributes_[1]->get().r;
+    minMaxes[1][1] = attributes_[1]->get().g;
+
+    minMaxes[2][0] = attributes_[2]->get().r;
+    minMaxes[2][1] = attributes_[2]->get().g;
+
+    minMaxes[3][0] = attributes_[3]->get().r;
+    minMaxes[3][1] = attributes_[3]->get().g;
+
+    return minMaxes;
+}
+
+void RangeTraitProperty::addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+                                      bool useVolumeDataMap) {
+    const auto minVal = useVolumeDataMap
+                            ? vec2(volume->dataMap_.valueRange).x
+                            : static_cast<float>(util::volumeMinMax(volume.get()).first.x);
+    const auto maxVal = useVolumeDataMap
+                            ? vec2(volume->dataMap_.valueRange).y
+                            : static_cast<float>(util::volumeMinMax(volume.get()).second.x);
+
+    attributes_[numInitializedAttributes()]->setVisible(true);
+    attributes_[numInitializedAttributes()]->setStart(minVal);
+    attributes_[numInitializedAttributes()]->setEnd(maxVal);
+    attributes_[numInitializedAttributes()]->setRangeMin(minVal);
+    attributes_[numInitializedAttributes()]->setRangeMax(maxVal);
+    attributes_[numInitializedAttributes()]->setDisplayName(name);
+}
+
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
@@ -1,9 +1,38 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
 #include <inviwo/featurelevelsetsgl/properties/rangetraitproperty.h>
 #include <modules/base/algorithm/dataminmax.h>
 
 namespace inviwo {
-const std::string RangeTraitProperty::classIdentifier = "org.inviwo.RangeTraitProperty";
-std::string RangeTraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+std::string_view RangeTraitProperty::getClassIdentifier() const { return classIdentifier; }
 
 mat4 RangeTraitProperty::getAsMat4() const {
     mat4 minMaxes;
@@ -26,10 +55,10 @@ mat4 RangeTraitProperty::getAsMat4() const {
 void RangeTraitProperty::addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
                                       bool useVolumeDataMap) {
     const auto minVal = useVolumeDataMap
-                            ? vec2(volume->dataMap_.valueRange).x
+                            ? vec2(volume->dataMap.valueRange).x
                             : static_cast<float>(util::volumeMinMax(volume.get()).first.x);
     const auto maxVal = useVolumeDataMap
-                            ? vec2(volume->dataMap_.valueRange).y
+                            ? vec2(volume->dataMap.valueRange).y
                             : static_cast<float>(util::volumeMinMax(volume.get()).second.x);
 
     attributes_[numInitializedAttributes()]->setVisible(true);

--- a/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/rangetraitproperty.cpp
@@ -52,7 +52,7 @@ mat4 RangeTraitProperty::getAsMat4() const {
     return minMaxes;
 }
 
-void RangeTraitProperty::addAttribute(const std::string& name, std::shared_ptr<const Volume> volume,
+void RangeTraitProperty::addAttribute(std::string_view name, std::shared_ptr<const Volume> volume,
                                       bool useVolumeDataMap) {
     const auto minVal = useVolumeDataMap
                             ? vec2(volume->dataMap.valueRange).x

--- a/multivis/featurelevelsetsgl/src/properties/traitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/traitproperty.cpp
@@ -1,0 +1,6 @@
+#include <inviwo/featurelevelsetsgl/properties/traitproperty.h>
+
+namespace inviwo {
+const std::string TraitProperty::classIdentifier = "org.inviwo.TraitProperty";
+std::string TraitProperty::getClassIdentifier() const { return classIdentifier; }
+}  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/properties/traitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/traitproperty.cpp
@@ -1,6 +1,36 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022-2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
 #include <inviwo/featurelevelsetsgl/properties/traitproperty.h>
 
 namespace inviwo {
-const std::string TraitProperty::classIdentifier = "org.inviwo.TraitProperty";
-std::string TraitProperty::getClassIdentifier() const { return classIdentifier; }
+
+std::string_view TraitProperty::getClassIdentifier() const { return classIdentifier; }
+
 }  // namespace inviwo

--- a/multivis/featurelevelsetsgl/src/properties/traitproperty.cpp
+++ b/multivis/featurelevelsetsgl/src/properties/traitproperty.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2022-2025 Inviwo Foundation
+ * Copyright (c) 2022-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/multivis/featurelevelsetsgl/tests/unittests/featurelevelsetsgl-unittest-main.cpp
+++ b/multivis/featurelevelsetsgl/tests/unittests/featurelevelsetsgl-unittest-main.cpp
@@ -1,0 +1,66 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2021 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#ifdef _MSC_VER
+#pragma comment(linker, "/SUBSYSTEM:CONSOLE")
+#ifdef IVW_ENABLE_MSVC_MEM_LEAK_TEST
+#include <vld.h>
+#endif
+#endif
+
+#include <inviwo/core/util/logcentral.h>
+#include <inviwo/core/util/consolelogger.h>
+#include <inviwo/testutil/configurablegtesteventlistener.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
+
+int main(int argc, char** argv) {
+    using namespace inviwo;
+    LogCentral::init();
+    auto logger = std::make_shared<ConsoleLogger>();
+    LogCentral::getPtr()->setVerbosity(LogVerbosity::Error);
+    LogCentral::getPtr()->registerLogger(logger);
+
+    int ret = -1;
+    {
+#ifdef IVW_ENABLE_MSVC_MEM_LEAK_TEST
+        VLDDisable();
+        ::testing::InitGoogleTest(&argc, argv);
+        VLDEnable();
+#else
+        ::testing::InitGoogleTest(&argc, argv);
+#endif
+        inviwo::ConfigurableGTestEventListener::setup();
+        ret = RUN_ALL_TESTS();
+    }
+    return ret;
+}

--- a/multivis/featurelevelsetsgl/tests/unittests/featurelevelsetsgl-unittest-main.cpp
+++ b/multivis/featurelevelsetsgl/tests/unittests/featurelevelsetsgl-unittest-main.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2021 Inviwo Foundation
+ * Copyright (c) 2021-2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Before I go, there is some code which I think would be nice to have available for the public. Unfortunately, I will not have time to put too much time into this so maybe we can make it a combined effort.

The code I added here includes some volume operations such as reduction, min/max, etc, implemented using compute shaders  and the feature level-sets (FLS), also implemented using compute shaders.

Everything works well enough to use it for standard cases (floating-point input fields). There are some things though that might need some attention. 

One things that comes to my mind is the injection of implicit functions into the shader code for FLS. Right now I have a number of placeholders and do a simple string replace. Maybe this is better done with Peter's new shader snippet thingy.

Another thing is that I have also not handled anything other than 32 bit floating point volumes as input since that is all I ever needed. Maybe dispatching should be added here.

In the shader code for volume reduction you can see that I tried using different samplers for different input data. The code compiles fine but the shader won't work for certain inputs (IIRC integer >16 bit).

I wrote a fair bit of documentation but I haven't checked for completeness.