### PR TITLE
MolVis,TensorVis: visualizer animation fix, #1562

### DIFF
--- a/molvis/molvisbase/include/inviwo/molvisbase/datavisualizer/molecularmeshvisualizer.h
+++ b/molvis/molvisbase/include/inviwo/molvisbase/datavisualizer/molecularmeshvisualizer.h
@@ -48,11 +48,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/molvis/molvisbase/include/inviwo/molvisbase/datavisualizer/molecularsourcevisualizer.h
+++ b/molvis/molvisbase/include/inviwo/molvisbase/datavisualizer/molecularsourcevisualizer.h
@@ -48,11 +48,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/molvis/molvisbase/src/datavisualizer/molecularmeshvisualizer.cpp
+++ b/molvis/molvisbase/src/datavisualizer/molecularmeshvisualizer.cpp
@@ -69,16 +69,18 @@ bool MolecularMeshVisualizer::hasSourceProcessor() const { return true; }
 bool MolecularMeshVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> MolecularMeshVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
-    auto source =
-        net->addProcessor(util::makeProcessor<MolecularStructureSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
+    auto* source = net->addProcessor(
+        util::makeProcessor<MolecularStructureSource>(GP{0, 0} + origin, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> MolecularMeshVisualizer::addVisualizerNetwork(Outport* outport,
                                                                       ProcessorNetwork* net) const {
-    auto msm = net->addProcessor(util::makeProcessor<MolecularStructureToMesh>(GP{0, 3}));
+    const ivec2 origin = util::getPosition(outport->getProcessor());
+
+    auto* msm = net->addProcessor(util::makeProcessor<MolecularStructureToMesh>(GP{0, 3} + origin));
 
     net->addConnection(outport, msm->getInports()[0]);
 
@@ -86,9 +88,9 @@ std::vector<Processor*> MolecularMeshVisualizer::addVisualizerNetwork(Outport* o
 }
 
 std::vector<Processor*> MolecularMeshVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/molvis/molvisbase/src/datavisualizer/molecularsourcevisualizer.cpp
+++ b/molvis/molvisbase/src/datavisualizer/molecularsourcevisualizer.cpp
@@ -68,10 +68,10 @@ bool MolecularSourceVisualizer::hasSourceProcessor() const { return true; }
 bool MolecularSourceVisualizer::hasVisualizerNetwork() const { return false; }
 
 std::pair<Processor*, Outport*> MolecularSourceVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
-    auto source =
-        net->addProcessor(util::makeProcessor<MolecularStructureSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
+    auto* source = net->addProcessor(
+        util::makeProcessor<MolecularStructureSource>(GP{0, 0} + origin, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -81,7 +81,7 @@ std::vector<Processor*> MolecularSourceVisualizer::addVisualizerNetwork(Outport*
 }
 
 std::vector<Processor*> MolecularSourceVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
     return {};
 }
 

--- a/molvis/molvisgl/include/inviwo/molvisgl/datavisualizer/molecularmeshrendervisualizer.h
+++ b/molvis/molvisgl/include/inviwo/molvisgl/datavisualizer/molecularmeshrendervisualizer.h
@@ -48,11 +48,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/molvis/molvisgl/include/inviwo/molvisgl/datavisualizer/molecularstructurevisualizer.h
+++ b/molvis/molvisgl/include/inviwo/molvisgl/datavisualizer/molecularstructurevisualizer.h
@@ -48,11 +48,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/molvis/molvisgl/src/datavisualizer/molecularstructurevisualizer.cpp
+++ b/molvis/molvisgl/src/datavisualizer/molecularstructurevisualizer.cpp
@@ -71,18 +71,20 @@ bool MolecularStructureVisualizer::hasSourceProcessor() const { return true; }
 bool MolecularStructureVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> MolecularStructureVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
-    auto source =
-        net->addProcessor(util::makeProcessor<MolecularStructureSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
+    auto* source = net->addProcessor(
+        util::makeProcessor<MolecularStructureSource>(GP{0, 0} + origin, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> MolecularStructureVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    auto mr = net->addProcessor(util::makeProcessor<MolecularRenderer>(GP{0, 3}));
-    auto bg = net->addProcessor(util::makeProcessor<Background>(GP{0, 5}));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 7}));
+    const ivec2 origin = util::getPosition(outport->getProcessor());
+
+    auto* mr = net->addProcessor(util::makeProcessor<MolecularRenderer>(GP{0, 3} + origin));
+    auto* bg = net->addProcessor(util::makeProcessor<Background>(GP{0, 5} + origin));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 7} + origin));
 
     auto bgProc = static_cast<Background*>(bg);
     bgProc->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
@@ -96,9 +98,9 @@ std::vector<Processor*> MolecularStructureVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> MolecularStructureVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/tensorvis/tensorvisbase/include/inviwo/tensorvisbase/datavisualizer/anisotropyraycastingvisualizer.h
+++ b/tensorvis/tensorvisbase/include/inviwo/tensorvisbase/datavisualizer/anisotropyraycastingvisualizer.h
@@ -47,11 +47,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
 
 private:
     [[maybe_unused]] InviwoApplication* app_;

--- a/tensorvis/tensorvisbase/include/inviwo/tensorvisbase/datavisualizer/hyperlicvisualizer2d.h
+++ b/tensorvis/tensorvisbase/include/inviwo/tensorvisbase/datavisualizer/hyperlicvisualizer2d.h
@@ -48,11 +48,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2&) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2&) const override;
 
 private:
     [[maybe_unused]] InviwoApplication* app_;

--- a/tensorvis/tensorvisbase/include/inviwo/tensorvisbase/datavisualizer/hyperlicvisualizer3d.h
+++ b/tensorvis/tensorvisbase/include/inviwo/tensorvisbase/datavisualizer/hyperlicvisualizer3d.h
@@ -48,11 +48,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& origin) const override;
 
 private:
     [[maybe_unused]] InviwoApplication* app_;

--- a/tensorvis/tensorvisbase/src/datavisualizer/anisotropyraycastingvisualizer.cpp
+++ b/tensorvis/tensorvisbase/src/datavisualizer/anisotropyraycastingvisualizer.cpp
@@ -70,18 +70,20 @@ bool AnisotropyRaycastingVisualizer::hasSourceProcessor() const { return false; 
 bool AnisotropyRaycastingVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> AnisotropyRaycastingVisualizer::addSourceProcessor(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
     return {nullptr, nullptr};
 }
 
 std::vector<Processor*> AnisotropyRaycastingVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto aniso = net->addProcessor(util::makeProcessor<TensorField3DAnisotropy>(GP{0, 3}));
-    auto cubep = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 6}));
-    auto entry = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 9}));
-    auto volra = net->addProcessor(util::makeProcessor<VolumeRaycaster>(GP{0, 12}));
-    auto canva = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15}));
+    auto* aniso =
+        net->addProcessor(util::makeProcessor<TensorField3DAnisotropy>(GP{0, 3} + initialPos));
+    auto* cubep = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 6} + initialPos));
+    auto* entry = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 9} + initialPos));
+    auto* volra = net->addProcessor(util::makeProcessor<VolumeRaycaster>(GP{0, 12} + initialPos));
+    auto* canva = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15} + initialPos));
 
     net->addConnection(aniso->getOutports()[0], cubep->getInports()[0]);
     net->addConnection(cubep->getOutports()[0], entry->getInports()[0]);
@@ -96,9 +98,8 @@ std::vector<Processor*> AnisotropyRaycastingVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> AnisotropyRaycastingVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path&, ProcessorNetwork*) const {
-
-    return {nullptr};
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
+    return {};
 }
 
 }  // namespace inviwo

--- a/tensorvis/tensorvisbase/src/datavisualizer/hyperlicvisualizer2d.cpp
+++ b/tensorvis/tensorvisbase/src/datavisualizer/hyperlicvisualizer2d.cpp
@@ -66,16 +66,17 @@ bool HyperLICVisualizer2D::hasSourceProcessor() const { return false; }
 bool HyperLICVisualizer2D::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> HyperLICVisualizer2D::addSourceProcessor(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
     return {nullptr, nullptr};
 }
 
 std::vector<Processor*> HyperLICVisualizer2D::addVisualizerNetwork(Outport* outport,
                                                                    ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto noiser = net->addProcessor(util::makeProcessor<NoiseGenerator2D>(GP{1, 3}));
-    auto hlicer = net->addProcessor(util::makeProcessor<TensorFieldLIC>(GP{0, 6}));
-    auto canvas = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9}));
+    auto* noiser = net->addProcessor(util::makeProcessor<NoiseGenerator2D>(GP{1, 3} + initialPos));
+    auto* hlicer = net->addProcessor(util::makeProcessor<TensorFieldLIC>(GP{0, 6} + initialPos));
+    auto* canvas = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
 
     net->addConnection(noiser->getOutports()[0], hlicer->getInports()[1]);
     net->addConnection(hlicer->getOutports()[0], canvas->getInports()[0]);
@@ -86,9 +87,9 @@ std::vector<Processor*> HyperLICVisualizer2D::addVisualizerNetwork(Outport* outp
 }
 
 std::vector<Processor*> HyperLICVisualizer2D::addSourceAndVisualizerNetwork(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
 
-    return {nullptr};
+    return {};
 }
 
 }  // namespace inviwo

--- a/tensorvis/tensorvisbase/src/datavisualizer/hyperlicvisualizer3d.cpp
+++ b/tensorvis/tensorvisbase/src/datavisualizer/hyperlicvisualizer3d.cpp
@@ -68,17 +68,19 @@ bool HyperLICVisualizer3D::hasSourceProcessor() const { return false; }
 bool HyperLICVisualizer3D::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> HyperLICVisualizer3D::addSourceProcessor(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
     return {nullptr, nullptr};
 }
 
 std::vector<Processor*> HyperLICVisualizer3D::addVisualizerNetwork(Outport* outport,
                                                                    ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto slicer = net->addProcessor(util::makeProcessor<TensorFieldSlice>(GP{0, 3}));
-    auto noiser = net->addProcessor(util::makeProcessor<NoiseGenerator2D>(GP{1, 6}));
-    auto hlicer = net->addProcessor(util::makeProcessor<TensorFieldLIC>(GP{0, 9}));
-    auto canvas = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 12}));
+    auto* slicer = net->addProcessor(util::makeProcessor<TensorFieldSlice>(GP{0, 3} + initialPos));
+    auto* noiser = net->addProcessor(util::makeProcessor<NoiseGenerator2D>(GP{1, 6} + initialPos));
+    auto* hlicer = net->addProcessor(util::makeProcessor<TensorFieldLIC>(GP{0, 9} + initialPos));
+    auto* canvas =
+        net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 12} + initialPos));
 
     net->addConnection(slicer->getOutports()[0], hlicer->getInports()[0]);
     net->addConnection(noiser->getOutports()[0], hlicer->getInports()[1]);
@@ -90,9 +92,9 @@ std::vector<Processor*> HyperLICVisualizer3D::addVisualizerNetwork(Outport* outp
 }
 
 std::vector<Processor*> HyperLICVisualizer3D::addSourceAndVisualizerNetwork(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
 
-    return {nullptr};
+    return {};
 }
 
 }  // namespace inviwo


### PR DESCRIPTION
* initially position visualizer networks at the outport they were invoked from